### PR TITLE
Fix build, tests, examples for SDL3 as of 2023-07-31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ image = ["sdl3-sys/image"]
 ttf = ["sdl3-sys/ttf"]
 # Use hidapi support in SDL. Only 2.0.12 and after
 hidapi = []
+# test_mode allows SDL to be initialised from a thread that is not the main thread
+test-mode = []
 
 use-bindgen = ["sdl3-sys/use-bindgen"]
 use-pkgconfig = ["sdl3-sys/use-pkgconfig"]

--- a/README.md
+++ b/README.md
@@ -725,6 +725,14 @@ the latest version of both Rust and Cargo, check that you've updated sdl3-rs
 to the latest version, and run `cargo clean`. If that fails, please let us know
 on the issue tracker.
 
+# Testing
+
+You can run the test suite via:
+```
+cargo test --features=test-mode
+```
+The `test-mode` feature allows running `Sdl::new()` from a thread other than the main thread, which is necessary for running the integration tests (`test/*.rs`).
+
 # Contributing
 
 We're looking for people to help get SDL3 support in Rust built, tested, and completed. You can help out!

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 fn main() {
-    #[cfg(any(target_os = "openbsd", target_os = "freebsd"))]
+    #[cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))]
     println!(r"cargo:rustc-link-search=/usr/local/lib");
 }

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -75,14 +75,14 @@ fn main() -> Result<(), String> {
         let ticks = timer.ticks() as i32;
 
         // set the current frame for time
-        source_rect_0.set_x(32 * ((ticks / 100) % frames_per_anim));
-        dest_rect_0.set_x(1 * ((ticks / 14) % 768) - 128);
+        source_rect_0.set_x((32 * ((ticks / 100) % frames_per_anim)) as f32);
+        dest_rect_0.set_x((1 * ((ticks / 14) % 768) - 128) as f32);
 
-        source_rect_1.set_x(32 * ((ticks / 100) % frames_per_anim));
-        dest_rect_1.set_x((1 * ((ticks / 12) % 768) - 672) * -1);
+        source_rect_1.set_x((32 * ((ticks / 100) % frames_per_anim)) as f32);
+        dest_rect_1.set_x(((1 * ((ticks / 12) % 768) - 672) * -1) as f32);
 
-        source_rect_2.set_x(32 * ((ticks / 100) % frames_per_anim));
-        dest_rect_2.set_x(1 * ((ticks / 10) % 768) - 128);
+        source_rect_2.set_x((32 * ((ticks / 100) % frames_per_anim)) as f32);
+        dest_rect_2.set_x((1 * ((ticks / 10) % 768) - 128) as f32);
 
         canvas.clear();
         // copy the frame to the canvas

--- a/examples/audio-capture-and-replay.rs
+++ b/examples/audio-capture-and-replay.rs
@@ -1,7 +1,7 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::audio::{AudioCallback, AudioSpecDesired};
-use sdl2::AudioSubsystem;
+use sdl3::audio::{AudioCallback, AudioSpecDesired};
+use sdl3::AudioSubsystem;
 use std::i16;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -140,7 +140,7 @@ fn replay_recorded_vec(
 }
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {

--- a/examples/audio-queue-squarewave.rs
+++ b/examples/audio-queue-squarewave.rs
@@ -1,6 +1,6 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::audio::AudioSpecDesired;
+use sdl3::audio::AudioSpecDesired;
 
 use std::time::Duration;
 
@@ -22,7 +22,7 @@ fn gen_wave(bytes_to_write: i32) -> Vec<i16> {
 }
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,6 +1,6 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::audio::{AudioCallback, AudioSpecDesired};
+use sdl3::audio::{AudioCallback, AudioSpecDesired};
 use std::time::Duration;
 
 struct SquareWave {
@@ -26,7 +26,7 @@ impl AudioCallback for SquareWave {
 }
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -1,6 +1,6 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::audio::{AudioCVT, AudioCallback, AudioSpecDesired, AudioSpecWAV};
+use sdl3::audio::{AudioCallback, AudioSpecDesired, AudioSpecWAV};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -38,12 +38,15 @@ impl AudioCallback for Sound {
     }
 }
 
+// FIXME: Convert to AudioStream library
+fn main() -> () {}
+#[cfg(feature = "")]
 fn main() -> Result<(), String> {
     let wav_file: Cow<'static, Path> = match std::env::args().nth(1) {
         None => Cow::from(Path::new("./assets/sine.wav")),
         Some(s) => Cow::from(PathBuf::from(s)),
     };
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {
@@ -85,3 +88,4 @@ fn main() -> Result<(), String> {
 
     Ok(())
 }
+

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,7 +1,7 @@
 extern crate rand;
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::audio::{AudioCallback, AudioSpecDesired};
+use sdl3::audio::{AudioCallback, AudioSpecDesired};
 use std::time::Duration;
 
 struct MyCallback {
@@ -22,7 +22,7 @@ impl AudioCallback for MyCallback {
 }
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpecDesired {

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,21 +1,21 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::image::{InitFlag, LoadSurface};
-use sdl2::keyboard::Keycode;
-use sdl2::mouse::Cursor;
-use sdl2::pixels::Color;
-use sdl2::rect::Rect;
-use sdl2::surface::Surface;
+use sdl3::event::Event;
+use sdl3::image::{InitFlag, LoadSurface};
+use sdl3::keyboard::Keycode;
+use sdl3::mouse::Cursor;
+use sdl3::pixels::Color;
+use sdl3::rect::Rect;
+use sdl3::surface::Surface;
 use std::env;
 use std::path::Path;
 
 pub fn run(png: &Path) -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
-    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG)?;
+    let _image_context = sdl3::image::init(InitFlag::PNG | InitFlag::JPG)?;
     let window = video_subsystem
-        .window("rust-sdl2 demo: Cursor", 800, 600)
+        .window("rust-sdl3 demo: Cursor", 800, 600)
         .position_centered()
         .build()
         .map_err(|e| e.to_string())?;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,16 +1,16 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::Color;
 use std::time::Duration;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
-        .window("rust-sdl2 demo: Video", 800, 600)
+        .window("rust-sdl3 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,16 +1,16 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::Color;
 use std::time::Duration;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
-        .window("rust-sdl2 demo: Events", 800, 600)
+        .window("rust-sdl3 demo: Events", 800, 600)
         .position_centered()
         .resizable()
         .build()

--- a/examples/game-controller.rs
+++ b/examples/game-controller.rs
@@ -5,26 +5,22 @@ fn main() -> Result<(), String> {
     // video subsystem enabled:
     sdl3::hint::set("SDL_JOYSTICK_THREAD", "1");
 
-    let sdl_context = sdl2::init()?;
-    let game_controller_subsystem = sdl_context.game_controller()?;
+    let sdl_context = sdl3::init()?;
+    let gamepad_subsystem = sdl_context.gamepad()?;
 
-    let available = game_controller_subsystem
-        .num_joysticks()
-        .map_err(|e| format!("can't enumerate joysticks: {}", e))?;
+    let available = gamepad_subsystem
+        .num_gamepads()
+        .map_err(|e| format!("can't enumerate gamepads: {}", e))?;
 
-    println!("{} joysticks available", available);
+    println!("{} gamepads available", available);
 
     // Iterate over all available joysticks and look for game controllers.
     let mut controller = (0..available)
         .find_map(|id| {
-            if !game_controller_subsystem.is_game_controller(id) {
-                println!("{} is not a game controller", id);
-                return None;
-            }
 
-            println!("Attempting to open controller {}", id);
+            println!("Attempting to open gamepad {}", id);
 
-            match game_controller_subsystem.open(id) {
+            match gamepad_subsystem.open(id) {
                 Ok(c) => {
                     // We managed to find and open a game controller,
                     // exit the loop
@@ -37,14 +33,14 @@ fn main() -> Result<(), String> {
                 }
             }
         })
-        .expect("Couldn't open any controller");
+        .expect("Couldn't open any gamepad");
 
     println!("Controller mapping: {}", controller.mapping());
 
     let (mut lo_freq, mut hi_freq) = (0, 0);
 
     for event in sdl_context.event_pump()?.wait_iter() {
-        use sdl3::controller::Axis;
+        use sdl3::gamepad::Axis;
         use sdl3::event::Event;
 
         match event {

--- a/examples/game-of-life-unsafe-textures.rs
+++ b/examples/game-of-life-unsafe-textures.rs
@@ -1,21 +1,21 @@
-extern crate sdl2;
+extern crate sdl3;
 
 #[cfg(feature = "unsafe_textures")]
 use game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
 #[cfg(feature = "unsafe_textures")]
-use sdl2::event::Event;
+use sdl3::event::Event;
 #[cfg(feature = "unsafe_textures")]
-use sdl2::keyboard::Keycode;
+use sdl3::keyboard::Keycode;
 #[cfg(feature = "unsafe_textures")]
-use sdl2::mouse::MouseButton;
+use sdl3::mouse::MouseButton;
 #[cfg(feature = "unsafe_textures")]
-use sdl2::pixels::Color;
+use sdl3::pixels::Color;
 #[cfg(feature = "unsafe_textures")]
-use sdl2::rect::{Point, Rect};
+use sdl3::rect::{Point, Rect};
 #[cfg(feature = "unsafe_textures")]
-use sdl2::render::{Canvas, Texture};
+use sdl3::render::{Canvas, Texture};
 #[cfg(feature = "unsafe_textures")]
-use sdl2::video::Window;
+use sdl3::video::Window;
 
 #[cfg(feature = "unsafe_textures")]
 mod game_of_life {
@@ -212,7 +212,7 @@ fn dummy_texture<'a>(canvas: &mut Canvas<Window>) -> Result<(Texture, Texture), 
 
 #[cfg(feature = "unsafe_textures")]
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     // the window is the representation of a window in your operating system,
@@ -221,7 +221,7 @@ pub fn main() -> Result<(), String> {
     // `surface()` method.
     let window = video_subsystem
         .window(
-            "rust-sdl2 demo: Game of Life",
+            "rust-sdl3 demo: Game of Life",
             SQUARE_SIZE * PLAYGROUND_WIDTH,
             SQUARE_SIZE * PLAYGROUND_HEIGHT,
         )

--- a/examples/game-of-life.rs
+++ b/examples/game-of-life.rs
@@ -1,13 +1,13 @@
-extern crate sdl2;
+extern crate sdl3;
 
 use crate::game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::mouse::MouseButton;
-use sdl2::pixels::Color;
-use sdl2::rect::{Point, Rect};
-use sdl2::render::{Canvas, Texture, TextureCreator};
-use sdl2::video::{Window, WindowContext};
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::mouse::MouseButton;
+use sdl3::pixels::Color;
+use sdl3::rect::Point;
+use sdl3::render::{Canvas, Texture, TextureCreator, FRect};
+use sdl3::video::{Window, WindowContext};
 
 mod game_of_life {
     pub const SQUARE_SIZE: u32 = 16;
@@ -197,14 +197,13 @@ fn dummy_texture<'a>(
                         }
                     }
                 }
-            })
-            .map_err(|e| e.to_string())?;
+            });
     }
     Ok((square_texture1, square_texture2))
 }
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     // the window is the representation of a window in your operating system,
@@ -213,7 +212,7 @@ pub fn main() -> Result<(), String> {
     // `surface()` method.
     let window = video_subsystem
         .window(
-            "rust-sdl2 demo: Game of Life",
+            "rust-sdl3 demo: Game of Life",
             SQUARE_SIZE * PLAYGROUND_WIDTH,
             SQUARE_SIZE * PLAYGROUND_HEIGHT,
         )
@@ -225,7 +224,7 @@ pub fn main() -> Result<(), String> {
     // via hardware or software rendering. See CanvasBuilder for more info.
     let mut canvas = window
         .into_canvas()
-        .target_texture()
+        //.target_texture() //FIXME: Unclear how to migrate this to SDL3, cf: https://github.com/libsdl-org/SDL/issues/8059
         .present_vsync()
         .build()
         .map_err(|e| e.to_string())?;
@@ -303,11 +302,11 @@ pub fn main() -> Result<(), String> {
                 canvas.copy(
                     square_texture,
                     None,
-                    Rect::new(
-                        ((i % PLAYGROUND_WIDTH) * SQUARE_SIZE) as i32,
-                        ((i / PLAYGROUND_WIDTH) * SQUARE_SIZE) as i32,
-                        SQUARE_SIZE,
-                        SQUARE_SIZE,
+                    FRect::new(
+                        ((i % PLAYGROUND_WIDTH) * SQUARE_SIZE) as f32,
+                        ((i / PLAYGROUND_WIDTH) * SQUARE_SIZE) as f32,
+                        SQUARE_SIZE as f32,
+                        SQUARE_SIZE as f32,
                     ),
                 )?;
             }

--- a/examples/gfx-demo.rs
+++ b/examples/gfx-demo.rs
@@ -1,20 +1,20 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels;
 
-use sdl2::gfx::primitives::DrawRenderer;
+use sdl3::gfx::primitives::DrawRenderer;
 
 const SCREEN_WIDTH: u32 = 800;
 const SCREEN_HEIGHT: u32 = 600;
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsys = sdl_context.video()?;
     let window = video_subsys
         .window(
-            "rust-sdl2_gfx: draw line & FPSManager",
+            "rust-sdl3_gfx: draw line & FPSManager",
             SCREEN_WIDTH,
             SCREEN_HEIGHT,
         )

--- a/examples/haptic.rs
+++ b/examples/haptic.rs
@@ -1,7 +1,7 @@
-extern crate sdl2;
+extern crate sdl3;
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let joystick_subsystem = sdl_context.joystick()?;
     let haptic_subsystem = sdl_context.haptic()?;
 
@@ -30,7 +30,7 @@ fn main() -> Result<(), String> {
         .map_err(|e| e.to_string())?;
 
     for event in sdl_context.event_pump()?.wait_iter() {
-        use sdl2::event::Event;
+        use sdl3::event::Event;
 
         match event {
             Event::JoyAxisMotion {

--- a/examples/image-demo.rs
+++ b/examples/image-demo.rs
@@ -1,17 +1,17 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::image::{InitFlag, LoadTexture};
-use sdl2::keyboard::Keycode;
+use sdl3::event::Event;
+use sdl3::image::{InitFlag, LoadTexture};
+use sdl3::keyboard::Keycode;
 use std::env;
 use std::path::Path;
 
 pub fn run(png: &Path) -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
-    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG)?;
+    let _image_context = sdl3::image::init(InitFlag::PNG | InitFlag::JPG)?;
     let window = video_subsystem
-        .window("rust-sdl2 demo: Video", 800, 600)
+        .window("rust-sdl3 demo: Video", 800, 600)
         .position_centered()
         .build()
         .map_err(|e| e.to_string())?;

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -1,7 +1,7 @@
-extern crate sdl2;
+extern crate sdl3;
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let joystick_subsystem = sdl_context.joystick()?;
 
     let available = joystick_subsystem
@@ -34,7 +34,7 @@ fn main() -> Result<(), String> {
     let (mut lo_freq, mut hi_freq) = (0, 0);
 
     for event in sdl_context.event_pump()?.wait_iter() {
-        use sdl2::event::Event;
+        use sdl3::event::Event;
 
         match event {
             Event::JoyAxisMotion {

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -1,12 +1,12 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
 use std::collections::HashSet;
 use std::time::Duration;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let _window = video_subsystem

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -1,16 +1,16 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::messagebox::*;
-use sdl2::pixels::Color;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::messagebox::*;
+use sdl3::pixels::Color;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
-        .window("rust-sdl2 demo: Video", 800, 600)
+        .window("rust-sdl3 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()

--- a/examples/mixer-demo.rs
+++ b/examples/mixer-demo.rs
@@ -1,7 +1,7 @@
 /// Demonstrates the simultaneous mixing of music and sound effects.
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::mixer::{InitFlag, AUDIO_S16LSB, DEFAULT_CHANNELS};
+use sdl3::mixer::{InitFlag, AUDIO_S16LSB, DEFAULT_CHANNELS};
 use std::env;
 use std::path::Path;
 
@@ -19,9 +19,9 @@ fn main() -> Result<(), String> {
 }
 
 fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), String> {
-    println!("linked version: {}", sdl2::mixer::get_linked_version());
+    println!("linked version: {}", sdl3::mixer::get_linked_version());
 
-    let sdl = sdl2::init()?;
+    let sdl = sdl3::init()?;
     let _audio = sdl.audio()?;
     let mut timer = sdl.timer()?;
 
@@ -29,48 +29,48 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), String> {
     let format = AUDIO_S16LSB; // signed 16 bit samples, in little-endian byte order
     let channels = DEFAULT_CHANNELS; // Stereo
     let chunk_size = 1_024;
-    sdl2::mixer::open_audio(frequency, format, channels, chunk_size)?;
+    sdl3::mixer::open_audio(frequency, format, channels, chunk_size)?;
     let _mixer_context =
-        sdl2::mixer::init(InitFlag::MP3 | InitFlag::FLAC | InitFlag::MOD | InitFlag::OGG)?;
+        sdl3::mixer::init(InitFlag::MP3 | InitFlag::FLAC | InitFlag::MOD | InitFlag::OGG)?;
 
     // Number of mixing channels available for sound effect `Chunk`s to play
     // simultaneously.
-    sdl2::mixer::allocate_channels(4);
+    sdl3::mixer::allocate_channels(4);
 
     {
-        let n = sdl2::mixer::get_chunk_decoders_number();
+        let n = sdl3::mixer::get_chunk_decoders_number();
         println!("available chunk(sample) decoders: {}", n);
         for i in 0..n {
-            println!("  decoder {} => {}", i, sdl2::mixer::get_chunk_decoder(i));
+            println!("  decoder {} => {}", i, sdl3::mixer::get_chunk_decoder(i));
         }
     }
 
     {
-        let n = sdl2::mixer::get_music_decoders_number();
+        let n = sdl3::mixer::get_music_decoders_number();
         println!("available music decoders: {}", n);
         for i in 0..n {
-            println!("  decoder {} => {}", i, sdl2::mixer::get_music_decoder(i));
+            println!("  decoder {} => {}", i, sdl3::mixer::get_music_decoder(i));
         }
     }
 
-    println!("query spec => {:?}", sdl2::mixer::query_spec());
+    println!("query spec => {:?}", sdl3::mixer::query_spec());
 
-    let music = sdl2::mixer::Music::from_file(music_file)?;
+    let music = sdl3::mixer::Music::from_file(music_file)?;
 
     fn hook_finished() {
         println!("play ends! from rust cb");
     }
 
-    sdl2::mixer::Music::hook_finished(hook_finished);
+    sdl3::mixer::Music::hook_finished(hook_finished);
 
     println!("music => {:?}", music);
     println!("music type => {:?}", music.get_type());
-    println!("music volume => {:?}", sdl2::mixer::Music::get_volume());
+    println!("music volume => {:?}", sdl3::mixer::Music::get_volume());
     println!("play => {:?}", music.play(1));
 
     {
         let sound_chunk = match sound_file {
-            Some(sound_file_path) => sdl2::mixer::Chunk::from_file(sound_file_path)
+            Some(sound_file_path) => sdl3::mixer::Chunk::from_file(sound_file_path)
                 .map_err(|e| format!("Cannot load sound file: {:?}", e))?,
             None => {
                 // One second of 500Hz sine wave using equation A * sin(2 * PI * f * t)
@@ -82,14 +82,14 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), String> {
                             as i16
                     })
                     .collect();
-                sdl2::mixer::Chunk::from_raw_buffer(buffer)
+                sdl3::mixer::Chunk::from_raw_buffer(buffer)
                     .map_err(|e| format!("Cannot get chunk from buffer: {:?}", e))?
             }
         };
 
         println!("chunk volume => {:?}", sound_chunk.get_volume());
         println!("playing sound twice");
-        sdl2::mixer::Channel::all().play(&sound_chunk, 1)?;
+        sdl3::mixer::Channel::all().play(&sound_chunk, 1)?;
 
         // This delay is needed because when the `Chunk` goes out of scope,
         // the sound effect stops playing. Delay long enough to hear the
@@ -100,7 +100,7 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), String> {
 
     timer.delay(10_000);
 
-    println!("fading out ... {:?}", sdl2::mixer::Music::fade_out(4_000));
+    println!("fading out ... {:?}", sdl3::mixer::Music::fade_out(4_000));
 
     timer.delay(5_000);
 
@@ -110,7 +110,7 @@ fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), String> {
     );
 
     timer.delay(5_000);
-    sdl2::mixer::Music::halt();
+    sdl3::mixer::Music::halt();
     timer.delay(1_000);
 
     println!("quitting sdl");

--- a/examples/mouse-state.rs
+++ b/examples/mouse-state.rs
@@ -1,12 +1,12 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
 use std::collections::HashSet;
 use std::time::Duration;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let _window = video_subsystem

--- a/examples/no-renderer.rs
+++ b/examples/no-renderer.rs
@@ -1,10 +1,10 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
-use sdl2::rect::Rect;
-use sdl2::video::Window;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::Color;
+use sdl3::rect::Rect;
+use sdl3::video::Window;
 use std::time::Duration;
 
 const WINDOW_WIDTH: u32 = 800;
@@ -21,7 +21,7 @@ enum Gradient {
 
 fn set_window_gradient(
     window: &mut Window,
-    event_pump: &sdl2::EventPump,
+    event_pump: &sdl3::EventPump,
     gradient: Gradient,
 ) -> Result<(), String> {
     let mut surface = window.surface(event_pump)?;
@@ -52,11 +52,11 @@ fn next_gradient(gradient: Gradient) -> Gradient {
 }
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let mut window = video_subsystem
-        .window("rust-sdl2 demo: No Renderer", WINDOW_WIDTH, WINDOW_HEIGHT)
+        .window("rust-sdl3 demo: No Renderer", WINDOW_WIDTH, WINDOW_HEIGHT)
         .position_centered()
         .build()
         .map_err(|e| e.to_string())?;

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -1,19 +1,19 @@
-/// Minimal example for getting sdl2 and wgpu working together with raw-window-handle.
+/// Minimal example for getting sdl3 and wgpu working together with raw-window-handle.
 extern crate pollster;
-extern crate sdl2;
+extern crate sdl3;
 extern crate wgpu;
 
 use std::borrow::Cow;
 use wgpu::SurfaceError;
 
-use sdl2::event::{Event, WindowEvent};
-use sdl2::keyboard::Keycode;
+use sdl3::event::{Event, WindowEvent};
+use sdl3::keyboard::Keycode;
 
 fn main() -> Result<(), String> {
     // Show logs from wgpu
     env_logger::init();
 
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
     let window = video_subsystem
         .window("Raw Window Handle Example", 800, 600)

--- a/examples/relative-mouse-state.rs
+++ b/examples/relative-mouse-state.rs
@@ -1,12 +1,12 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::mouse::MouseButton;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::mouse::MouseButton;
 use std::time::Duration;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let _window = video_subsystem

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -1,15 +1,15 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::{Color, PixelFormatEnum};
-use sdl2::rect::{Point, Rect};
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::{Color, PixelFormatEnum};
+use sdl3::render::{FPoint, FRect};
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
     let window = video_subsystem
-        .window("rust-sdl2 resource-manager demo", 800, 600)
+        .window("rust-sdl3 resource-manager demo", 800, 600)
         .position_centered()
         .build()
         .map_err(|e| e.to_string())?;
@@ -42,19 +42,18 @@ fn main() -> Result<(), String> {
                 texture_canvas.clear();
                 texture_canvas.set_draw_color(Color::RGBA(255, 0, 0, 255));
                 texture_canvas
-                    .fill_rect(Rect::new(0, 0, 400, 300))
+                    .fill_rect(FRect::new(0.0, 0.0, 400.0, 300.0))
                     .expect("could not fill rect");
-            })
-            .map_err(|e| e.to_string())?;
+            });
         canvas.set_draw_color(Color::RGBA(0, 0, 0, 255));
-        let dst = Some(Rect::new(0, 0, 400, 300));
+        let dst = Some(FRect::new(0.0, 0.0, 400.0, 300.0));
         canvas.clear();
         canvas.copy_ex(
             &texture,
             None,
             dst,
             angle,
-            Some(Point::new(400, 300)),
+            Some(FPoint::new(400.0, 300.0)),
             false,
             false,
         )?;

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -1,16 +1,16 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::PixelFormatEnum;
-use sdl2::rect::Rect;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::PixelFormatEnum;
+use sdl3::render::FRect;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
-        .window("rust-sdl2 demo: Video", 800, 600)
+        .window("rust-sdl3 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
@@ -35,11 +35,11 @@ pub fn main() -> Result<(), String> {
     })?;
 
     canvas.clear();
-    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)))?;
+    canvas.copy(&texture, None, Some(FRect::new(100.0, 100.0, 256.0, 256.0)))?;
     canvas.copy_ex(
         &texture,
         None,
-        Some(Rect::new(450, 100, 256, 256)),
+        Some(FRect::new(450.0, 100.0, 256.0, 256.0)),
         30.0,
         None,
         false,

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -1,16 +1,16 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::PixelFormatEnum;
-use sdl2::rect::Rect;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::PixelFormatEnum;
+use sdl3::render::FRect;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
-        .window("rust-sdl2 demo: Video", 800, 600)
+        .window("rust-sdl3 demo: Video", 800, 600)
         .position_centered()
         .opengl()
         .build()
@@ -52,7 +52,7 @@ pub fn main() -> Result<(), String> {
     })?;
 
     canvas.clear();
-    canvas.copy(&texture, None, Some(Rect::new(100, 100, 256, 256)))?;
+    canvas.copy(&texture, None, Some(FRect::new(100.0, 100.0, 256.0, 256.0)))?;
     canvas.present();
 
     let mut event_pump = sdl_context.event_pump()?;

--- a/examples/resource-manager.rs
+++ b/examples/resource-manager.rs
@@ -1,11 +1,11 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::image::{InitFlag, LoadTexture};
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
-use sdl2::render::{Texture, TextureCreator};
-use sdl2::ttf::{Font, Sdl2TtfContext};
+use sdl3::event::Event;
+use sdl3::image::{InitFlag, LoadTexture};
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::Color;
+use sdl3::render::{Texture, TextureCreator};
+use sdl3::ttf::{Font, Sdl3TtfContext};
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
@@ -22,12 +22,12 @@ fn main() -> Result<(), String> {
         let image_path = &args[1];
         let font_path = &args[2];
 
-        let sdl_context = sdl2::init()?;
+        let sdl_context = sdl3::init()?;
         let video_subsystem = sdl_context.video()?;
-        let font_context = sdl2::ttf::init().map_err(|e| e.to_string())?;
-        let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG)?;
+        let font_context = sdl3::ttf::init().map_err(|e| e.to_string())?;
+        let _image_context = sdl3::image::init(InitFlag::PNG | InitFlag::JPG)?;
         let window = video_subsystem
-            .window("rust-sdl2 resource-manager demo", 800, 600)
+            .window("rust-sdl3 resource-manager demo", 800, 600)
             .position_centered()
             .build()
             .map_err(|e| e.to_string())?;
@@ -81,7 +81,7 @@ fn main() -> Result<(), String> {
 }
 
 type TextureManager<'l, T> = ResourceManager<'l, String, Texture<'l>, TextureCreator<T>>;
-type FontManager<'l> = ResourceManager<'l, FontDetails, Font<'l, 'static>, Sdl2TtfContext>;
+type FontManager<'l> = ResourceManager<'l, FontDetails, Font<'l, 'static>, Sdl3TtfContext>;
 
 // Generic struct to cache any resource loaded by a ResourceLoader
 pub struct ResourceManager<'l, K, R, L>
@@ -134,7 +134,7 @@ impl<'l, T> ResourceLoader<'l, Texture<'l>> for TextureCreator<T> {
 }
 
 // Font Context knows how to load Fonts
-impl<'l> ResourceLoader<'l, Font<'l, 'static>> for Sdl2TtfContext {
+impl<'l> ResourceLoader<'l, Font<'l, 'static>> for Sdl3TtfContext {
     type Args = FontDetails;
     fn load(&'l self, details: &FontDetails) -> Result<Font<'l, 'static>, String> {
         println!("LOADED A FONT");

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -1,11 +1,11 @@
 use std::time::{Duration, Instant};
 
-use sdl2::{event::Event, sensor::SensorType};
+use sdl3::{event::Event, sensor::SensorType};
 
-extern crate sdl2;
+extern crate sdl3;
 
 fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let game_controller_subsystem = sdl_context.game_controller()?;
 
     let available = game_controller_subsystem

--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -1,13 +1,13 @@
-extern crate sdl2;
+extern crate sdl3;
 
 use std::env;
 use std::path::Path;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
-use sdl2::rect::Rect;
-use sdl2::render::TextureQuery;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::Color;
+use sdl3::rect::Rect;
+use sdl3::render::TextureQuery;
 
 static SCREEN_WIDTH: u32 = 800;
 static SCREEN_HEIGHT: u32 = 600;
@@ -44,12 +44,12 @@ fn get_centered_rect(rect_width: u32, rect_height: u32, cons_width: u32, cons_he
 }
 
 fn run(font_path: &Path) -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsys = sdl_context.video()?;
-    let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string())?;
+    let ttf_context = sdl3::ttf::init().map_err(|e| e.to_string())?;
 
     let window = video_subsys
-        .window("SDL2_TTF Example", SCREEN_WIDTH, SCREEN_HEIGHT)
+        .window("SDL3_TTF Example", SCREEN_WIDTH, SCREEN_HEIGHT)
         .position_centered()
         .opengl()
         .build()
@@ -60,7 +60,7 @@ fn run(font_path: &Path) -> Result<(), String> {
 
     // Load a font
     let mut font = ttf_context.load_font(font_path, 128)?;
-    font.set_style(sdl2::ttf::FontStyle::BOLD);
+    font.set_style(sdl3::ttf::FontStyle::BOLD);
 
     // render a surface, and convert it to a texture bound to the canvas
     let surface = font
@@ -107,7 +107,7 @@ fn run(font_path: &Path) -> Result<(), String> {
 fn main() -> Result<(), String> {
     let args: Vec<_> = env::args().collect();
 
-    println!("linked sdl2_ttf: {}", sdl2::ttf::get_linked_version());
+    println!("linked sdl3_ttf: {}", sdl3::ttf::get_linked_version());
 
     if args.len() < 2 {
         println!("Usage: ./demo font.[ttf|ttc|fon]")

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,15 +1,15 @@
-extern crate sdl2;
+extern crate sdl3;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
+use sdl3::pixels::Color;
 
 pub fn main() -> Result<(), String> {
-    let sdl_context = sdl2::init()?;
+    let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
 
     let window = video_subsystem
-        .window("rust-sdl2 demo: Window", 800, 600)
+        .window("rust-sdl3 demo: Window", 800, 600)
         .resizable()
         .build()
         .map_err(|e| e.to_string())?;

--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -404,7 +404,7 @@ impl AudioSpecWAV {
         unsafe {
             let ret = sys::SDL_LoadWAV_RW(
                 src.raw(),
-                0,
+                sys::SDL_bool::SDL_FALSE,
                 desired.as_mut_ptr(),
                 &mut audio_buf,
                 &mut audio_len,

--- a/src/sdl3/clipboard.rs
+++ b/src/sdl3/clipboard.rs
@@ -10,7 +10,7 @@ use crate::sys;
 /// These functions require the video subsystem to be initialized.
 ///
 /// ```no_run
-/// let sdl_context = sdl2::init().unwrap();
+/// let sdl_context = sdl3::init().unwrap();
 /// let video_subsystem = sdl_context.video().unwrap();
 ///
 /// video_subsystem.clipboard().set_clipboard_text("Hello World!").unwrap();

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -446,8 +446,8 @@ pub enum DisplayEvent {
 
 impl DisplayEvent {
     #[allow(clippy::match_same_arms)]
-    fn from_ll(id: u8, data1: i32) -> DisplayEvent {
-        match unsafe { transmute(id as u32) } {
+    fn from_ll(id: u32, data1: i32) -> DisplayEvent {
+        match unsafe { transmute(id) } {
             SDL_EventType::SDL_EVENT_DISPLAY_ORIENTATION => {
                 let orientation = if data1 as u32
                     > sys::SDL_DisplayOrientation::SDL_ORIENTATION_PORTRAIT_FLIPPED as u32
@@ -513,52 +513,91 @@ pub enum WindowEvent {
 
 impl WindowEvent {
     #[allow(clippy::match_same_arms)]
-    fn from_ll(id: u8, data1: i32, data2: i32) -> WindowEvent {
-        match id {
-            0 => WindowEvent::None,
-            1 => WindowEvent::Shown,
-            2 => WindowEvent::Hidden,
-            3 => WindowEvent::Exposed,
-            4 => WindowEvent::Moved(data1, data2),
-            5 => WindowEvent::Resized(data1, data2),
-            6 => WindowEvent::PixelSizeChanged(data1, data2),
-            7 => WindowEvent::Minimized,
-            8 => WindowEvent::Maximized,
-            9 => WindowEvent::Restored,
-            10 => WindowEvent::MouseEnter,
-            11 => WindowEvent::MouseLeave,
-            12 => WindowEvent::FocusGained,
-            13 => WindowEvent::FocusLost,
-            14 => WindowEvent::CloseRequested,
-            15 => WindowEvent::TakeFocus,
-            16 => WindowEvent::HitTest(data1, data2),
-            17 => WindowEvent::ICCProfChanged,
-            18 => WindowEvent::DisplayChanged(data1),
-            _ => WindowEvent::None,
+    fn from_ll(id: u32, data1: i32, data2: i32) -> WindowEvent {
+        match EventType::try_from(id) {
+            Ok(ev) => match ev {
+                EventType::WindowShown =>
+		    WindowEvent::Shown,
+                EventType::WindowHidden =>
+		    WindowEvent::Hidden,
+                EventType::WindowExposed =>
+		    WindowEvent::Exposed,
+                EventType::WindowMoved =>
+		    WindowEvent::Moved(data1, data2),
+                EventType::WindowResized =>
+		    WindowEvent::Resized(data1, data2),
+                EventType::WindowPixelSizeChanged =>
+		    WindowEvent::PixelSizeChanged(data1, data2),
+                EventType::WindowMinimized =>
+		    WindowEvent::Minimized,
+                EventType::WindowMaximized =>
+		    WindowEvent::Maximized,
+                EventType::WindowRestored =>
+		    WindowEvent::Restored,
+                EventType::WindowMouseEnter =>
+		    WindowEvent::MouseEnter,
+                EventType::WindowMouseLeave =>
+		    WindowEvent::MouseLeave,
+                EventType::WindowFocusGained =>
+		    WindowEvent::FocusGained,
+                EventType::WindowFocusLost =>
+		    WindowEvent::FocusLost,
+                EventType::WindowCloseRequested =>
+		    WindowEvent::CloseRequested,
+                EventType::WindowTakeFocus =>
+		    WindowEvent::TakeFocus,
+                EventType::WindowHitTest =>
+		    WindowEvent::HitTest(data1, data2),
+                EventType::WindowICCProfileChanged =>
+		    WindowEvent::ICCProfChanged,
+                EventType::WindowDisplayChanged =>
+		    WindowEvent::DisplayChanged(data1),
+		_ => WindowEvent::None,
+            }
+            Err(_) => WindowEvent::None,
         }
     }
 
-    fn to_ll(&self) -> (u8, i32, i32) {
+    fn to_ll(&self) -> (EventType, i32, i32) {
         match *self {
-            WindowEvent::None => (0, 0, 0),
-            WindowEvent::Shown => (1, 0, 0),
-            WindowEvent::Hidden => (2, 0, 0),
-            WindowEvent::Exposed => (3, 0, 0),
-            WindowEvent::Moved(d1, d2) => (4, d1, d2),
-            WindowEvent::Resized(d1, d2) => (5, d1, d2),
-            WindowEvent::PixelSizeChanged(d1, d2) => (6, d1, d2),
-            WindowEvent::Minimized => (7, 0, 0),
-            WindowEvent::Maximized => (8, 0, 0),
-            WindowEvent::Restored => (9, 0, 0),
-            WindowEvent::MouseEnter => (10, 0, 0),
-            WindowEvent::MouseLeave => (11, 0, 0),
-            WindowEvent::FocusGained => (12, 0, 0),
-            WindowEvent::FocusLost => (13, 0, 0),
-            WindowEvent::CloseRequested => (14, 0, 0),
-            WindowEvent::TakeFocus => (15, 0, 0),
-            WindowEvent::HitTest(d1, d2) => (16, d1, d2),
-            WindowEvent::ICCProfChanged => (17, 0, 0),
-            WindowEvent::DisplayChanged(d1) => (18, d1, 0),
+            WindowEvent::None =>
+		panic!("Cannot convert WindowEvent::None"),
+            WindowEvent::Shown =>
+		(EventType::WindowShown, 0, 0),
+            WindowEvent::Hidden =>
+		(EventType::WindowHidden, 0, 0),
+            WindowEvent::Exposed =>
+		(EventType::WindowExposed, 0, 0),
+            WindowEvent::Moved(d1, d2) =>
+		(EventType::WindowMoved, d1, d2),
+            WindowEvent::Resized(d1, d2) =>
+		(EventType::WindowResized, d1, d2),
+            WindowEvent::PixelSizeChanged(d1, d2) =>
+		(EventType::WindowPixelSizeChanged, d1, d2),
+            WindowEvent::Minimized =>
+		(EventType::WindowMinimized, 0, 0),
+            WindowEvent::Maximized =>
+		(EventType::WindowMaximized, 0, 0),
+            WindowEvent::Restored =>
+		(EventType::WindowRestored, 0, 0),
+            WindowEvent::MouseEnter =>
+		(EventType::WindowMouseEnter, 0, 0),
+            WindowEvent::MouseLeave =>
+		(EventType::WindowMouseLeave, 0, 0),
+            WindowEvent::FocusGained =>
+		(EventType::WindowFocusGained, 0, 0),
+            WindowEvent::FocusLost =>
+		(EventType::WindowFocusLost, 0, 0),
+            WindowEvent::CloseRequested =>
+		(EventType::WindowCloseRequested, 0, 0),
+            WindowEvent::TakeFocus =>
+		(EventType::WindowTakeFocus, 0, 0),
+            WindowEvent::HitTest(d1, d2) =>
+		(EventType::WindowHitTest, d1, d2),
+            WindowEvent::ICCProfChanged =>
+		(EventType::WindowICCProfileChanged, 0, 0),
+            WindowEvent::DisplayChanged(d1) =>
+		(EventType::WindowDisplayChanged, d1, 0),
         }
     }
 
@@ -615,7 +654,7 @@ pub enum Event {
 
     Display {
         timestamp: u64,
-        display_index: i32,
+        display_index: u32,
         display_event: DisplayEvent,
     },
     Window {
@@ -936,20 +975,6 @@ pub enum Event {
     Unknown {
         timestamp: u64,
         type_: u32,
-    },
-
-    DisplayOrientation {
-        timestamp: u64,
-        display_index: u32,
-        data1: i32,
-    },
-    DisplayConnected {
-        timestamp: u64,
-        display_index: u32,
-    },
-    DisplayDisconnected {
-        timestamp: u64,
-        display_index: u32,
     },
 }
 
@@ -1488,150 +1513,33 @@ impl Event {
         let event_type: EventType = EventType::try_from(raw_type as u32).unwrap_or(EventType::User);
         unsafe {
             match event_type {
-                EventType::WindowShown => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Shown,
-                    }
-                }
-                EventType::WindowHidden => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Hidden,
-                    }
-                }
-                EventType::WindowExposed => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Exposed,
-                    }
-                }
-                EventType::WindowMoved => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Moved(event.data1, event.data2),
-                    }
-                }
-                EventType::WindowResized => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Resized(event.data1, event.data2),
-                    }
-                }
-                EventType::WindowPixelSizeChanged => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::PixelSizeChanged(event.data1, event.data2),
-                    }
-                }
-                EventType::WindowMinimized => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Minimized,
-                    }
-                }
-                EventType::WindowMaximized => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Maximized,
-                    }
-                }
-                EventType::WindowRestored => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::Restored,
-                    }
-                }
-                EventType::WindowMouseEnter => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::MouseEnter,
-                    }
-                }
-                EventType::WindowMouseLeave => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::MouseLeave,
-                    }
-                }
-                EventType::WindowFocusGained => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::FocusGained,
-                    }
-                }
-                EventType::WindowFocusLost => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::FocusLost,
-                    }
-                }
-                EventType::WindowCloseRequested => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::CloseRequested,
-                    }
-                }
-                EventType::WindowTakeFocus => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::TakeFocus,
-                    }
-                }
-                EventType::WindowHitTest => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::HitTest(event.data1 as i32, event.data2 as i32),
-                    }
-                }
-                EventType::WindowICCProfileChanged => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::ICCProfChanged,
-                    }
-                }
-                EventType::WindowDisplayChanged => {
-                    let event = raw.window;
-                    Event::Window {
-                        timestamp: event.timestamp,
-                        window_id: event.windowID,
-                        win_event: WindowEvent::DisplayChanged(event.data1),
-                    }
-                }
+
+		EventType::WindowShown
+		    | EventType::WindowHidden
+		    | EventType::WindowExposed
+		    | EventType::WindowMoved
+		    | EventType::WindowResized
+		    | EventType::WindowPixelSizeChanged
+		    | EventType::WindowMinimized
+		    | EventType::WindowMaximized
+		    | EventType::WindowRestored
+		    | EventType::WindowMouseEnter
+		    | EventType::WindowMouseLeave
+		    | EventType::WindowFocusGained
+		    | EventType::WindowFocusLost
+		    | EventType::WindowCloseRequested
+		    | EventType::WindowTakeFocus
+		    | EventType::WindowHitTest
+		    | EventType::WindowICCProfileChanged
+		    | EventType::WindowDisplayChanged => {
+			let event = raw.window;
+			Event::Window {
+                            timestamp: event.timestamp,
+                            window_id: event.windowID,
+                            win_event: WindowEvent::from_ll(event.type_, event.data1, event.data2)
+			}
+		    }
+
 
                 EventType::Quit => {
                     let event = raw.quit;
@@ -1676,31 +1584,15 @@ impl Event {
                     }
                 }
 
-                EventType::DisplayOrientation => {
+                EventType::DisplayOrientation
+                    | EventType::DisplayConnected
+                    | EventType::DisplayDisconnected => {
                     let event = raw.display;
 
-                    Event::DisplayOrientation {
+                    Event::Display {
                         timestamp: event.timestamp,
                         display_index: event.displayID,
-                        data1: event.data1,
-                    }
-                }
-
-                EventType::DisplayConnected => {
-                    let event = raw.display;
-
-                    Event::DisplayConnected {
-                        timestamp: event.timestamp,
-                        display_index: event.displayID,
-                    }
-                }
-
-                EventType::DisplayDisconnected => {
-                    let event = raw.display;
-
-                    Event::DisplayDisconnected {
-                        timestamp: event.timestamp,
-                        display_index: event.displayID,
+                        display_event: DisplayEvent::from_ll(event.type_, event.data1),
                     }
                 }
 
@@ -2243,9 +2135,6 @@ impl Event {
         *match self {
             Self::Quit { timestamp, .. } => timestamp,
             Self::Window { timestamp, .. } => timestamp,
-            Self::DisplayConnected { timestamp, .. } => timestamp,
-            Self::DisplayDisconnected { timestamp, .. } => timestamp,
-            Self::DisplayOrientation { timestamp, .. } => timestamp,
             Self::AppTerminating { timestamp, .. } => timestamp,
             Self::AppLowMemory { timestamp, .. } => timestamp,
             Self::AppWillEnterBackground { timestamp, .. } => timestamp,
@@ -2253,7 +2142,6 @@ impl Event {
             Self::AppWillEnterForeground { timestamp, .. } => timestamp,
             Self::AppDidEnterForeground { timestamp, .. } => timestamp,
             Self::Display { timestamp, .. } => timestamp,
-            Self::Window { timestamp, .. } => timestamp,
             Self::KeyDown { timestamp, .. } => timestamp,
             Self::KeyUp { timestamp, .. } => timestamp,
             Self::TextEditing { timestamp, .. } => timestamp,

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -54,18 +54,18 @@ impl error::Error for AddMappingError {
 }
 
 impl GamepadSubsystem {
-    /// Retrieve the total number of attached joysticks *and* controllers identified by SDL.
+    /// Retrieve the total number of attached gamepads identified by SDL.
     #[doc(alias = "SDL_GetJoysticks")]
-    pub fn num_joysticks(&self, joystick_id: u32) -> Result<u32, String> {
-        let mut num_joysticks: i32 = 0;
+    pub fn num_gamepads(&self) -> Result<u32, String> {
+        let mut num_gamepads: i32 = 0;
         unsafe {
             // see: https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_joystickh
-            let joystick_ids = sys::SDL_GetJoysticks(&mut num_joysticks);
-            if (joystick_ids as *mut sys::SDL_Joystick) == std::ptr::null_mut() {
+            let gamepad_ids = sys::SDL_GetGamepads(&mut num_gamepads);
+            if (gamepad_ids as *mut sys::SDL_Gamepad) == std::ptr::null_mut() {
                 return Err(get_error());
             } else {
-                sys::SDL_free(joystick_ids as *mut c_void);
-                return Ok(num_joysticks as u32);
+                sys::SDL_free(gamepad_ids as *mut c_void);
+                return Ok(num_gamepads as u32);
             };
         };
     }
@@ -424,13 +424,7 @@ impl Gamepad {
             let joystick = sys::SDL_GetGamepadJoystick(self.raw);
             sys::SDL_GetJoystickInstanceID(joystick)
         };
-
-        if result < 0 {
-            // Should only fail if the joystick is NULL.
-            panic!("{}", get_error())
-        } else {
-            result as u32
-        }
+        result as u32
     }
 
     /// Get the position of the given `axis`

--- a/src/sdl3/pixels.rs
+++ b/src/sdl3/pixels.rs
@@ -232,9 +232,9 @@ pub enum PixelFormatEnum {
     BGR565 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGR565 as i32,
     RGB24 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGB24 as i32,
     BGR24 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGR24 as i32,
-    RGB888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGB888 as i32,
+    XRGB8888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_XRGB8888 as i32,
     RGBX8888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGBX8888 as i32,
-    BGR888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGR888 as i32,
+    XBGR8888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_XBGR8888 as i32,
     BGRX8888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGRX8888 as i32,
     ARGB8888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_ARGB8888 as i32,
     RGBA8888 = sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGBA8888 as i32,
@@ -340,9 +340,9 @@ impl PixelFormatEnum {
             | PixelFormatEnum::RGB565
             | PixelFormatEnum::BGR565 => num_of_pixels * 2,
             PixelFormatEnum::RGB24 | PixelFormatEnum::BGR24 => num_of_pixels * 3,
-            PixelFormatEnum::RGB888
+            PixelFormatEnum::XRGB8888
             | PixelFormatEnum::RGBX8888
-            | PixelFormatEnum::BGR888
+            | PixelFormatEnum::XBGR8888
             | PixelFormatEnum::BGRX8888
             | PixelFormatEnum::ARGB8888
             | PixelFormatEnum::RGBA8888
@@ -383,9 +383,9 @@ impl PixelFormatEnum {
             | PixelFormatEnum::RGB565
             | PixelFormatEnum::BGR565 => 2,
             PixelFormatEnum::RGB24 | PixelFormatEnum::BGR24 => 3,
-            PixelFormatEnum::RGB888
+            PixelFormatEnum::XRGB8888
             | PixelFormatEnum::RGBX8888
-            | PixelFormatEnum::BGR888
+            | PixelFormatEnum::XBGR8888
             | PixelFormatEnum::BGRX8888
             | PixelFormatEnum::ARGB8888
             | PixelFormatEnum::RGBA8888
@@ -456,9 +456,9 @@ impl TryFrom<u32> for PixelFormatEnum {
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGR565 => BGR565,
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGB24 => RGB24,
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGR24 => BGR24,
-            sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGB888 => RGB888,
+            sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_XRGB8888 => XRGB8888,
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGBX8888 => RGBX8888,
-            sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGR888 => BGR888,
+            sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_XBGR8888 => XBGR8888,
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_BGRX8888 => BGRX8888,
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_ARGB8888 => ARGB8888,
             sys::SDL_PixelFormatEnum::SDL_PIXELFORMAT_RGBA8888 => RGBA8888,
@@ -512,25 +512,26 @@ fn test_pixel_format_enum() {
         PixelFormatEnum::BGR565,
         PixelFormatEnum::RGB24,
         PixelFormatEnum::BGR24,
-        PixelFormatEnum::RGB888,
+        PixelFormatEnum::XRGB8888,
         PixelFormatEnum::RGBX8888,
-        PixelFormatEnum::BGR888,
+        PixelFormatEnum::XBGR8888,
         PixelFormatEnum::BGRX8888,
         PixelFormatEnum::ARGB8888,
         PixelFormatEnum::RGBA8888,
         PixelFormatEnum::ABGR8888,
         PixelFormatEnum::BGRA8888,
         PixelFormatEnum::ARGB2101010,
-        PixelFormatEnum::YV12,
-        PixelFormatEnum::IYUV,
-        PixelFormatEnum::YUY2,
-        PixelFormatEnum::UYVY,
-        PixelFormatEnum::YVYU,
         PixelFormatEnum::Index8,
-        // These don't seem to be supported;
-        // the round-trip
-        //PixelFormatEnum::Unknown, PixelFormatEnum::Index1LSB,
-        //PixelFormatEnum::Index1MSB, PixelFormatEnum::Index4LSB,
+        PixelFormatEnum::Unknown,
+        //  These formats don't seem to survive the round-trip on all platforms;
+        //PixelFormatEnum::YV12,
+        //PixelFormatEnum::IYUV,
+        //PixelFormatEnum::YUY2,
+        //PixelFormatEnum::UYVY,
+        //PixelFormatEnum::YVYU,
+	//PixelFormatEnum::Index1LSB,
+        //PixelFormatEnum::Index1MSB,
+	//PixelFormatEnum::Index4LSB,
         //PixelFormatEnum::Index4MSB
     ];
 

--- a/src/sdl3/rect.rs
+++ b/src/sdl3/rect.rs
@@ -1,5 +1,4 @@
 //! Rectangles and points.
-#![allow(const_err)]
 
 use crate::sys;
 use std::convert::{AsMut, AsRef};

--- a/src/sdl3/render.rs
+++ b/src/sdl3/render.rs
@@ -32,6 +32,7 @@ use crate::common::{validate_int, IntegerOrSdlError};
 use crate::get_error;
 use crate::pixels;
 use crate::pixels::PixelFormatEnum;
+use crate::rect::Point;
 use crate::rect::Rect;
 use crate::surface;
 use crate::surface::{Surface, SurfaceContext, SurfaceRef};
@@ -125,6 +126,15 @@ impl FPoint {
     }
 }
 
+impl From<Point> for FPoint {
+    fn from(point: Point) -> Self {
+	FPoint::new(
+	    point.x as f32,
+	    point.y as f32,
+	    )
+    }
+}
+
 // floating-point rectangle
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct FRect {
@@ -144,6 +154,33 @@ impl FRect {
             w: self.w,
             h: self.h,
         }
+    }
+    pub fn set_x(&mut self, update: f32) {
+	self.x = update;
+    }
+    pub fn set_y(&mut self, update: f32) {
+	self.y = update;
+    }
+    pub fn set_w(&mut self, update: f32) {
+	self.w = update;
+    }
+    pub fn set_h(&mut self, update: f32) {
+	self.h = update;
+    }
+    pub fn set_xy(&mut self, update: FPoint) {
+	self.x = update.x;
+	self.y = update.y;
+    }
+}
+
+impl From<Rect> for FRect {
+    fn from(rect: Rect) -> Self {
+	FRect::new(
+	    rect.x as f32,
+	    rect.y as f32,
+	    rect.w as f32,
+	    rect.h as f32,
+	)
     }
 }
 

--- a/src/sdl3/rwops.rs
+++ b/src/sdl3/rwops.rs
@@ -1,6 +1,6 @@
 use crate::get_error;
 use libc::c_void;
-use libc::{c_char, c_int};
+use libc::c_char;
 use std::ffi::CString;
 use std::io;
 use std::marker::PhantomData;
@@ -58,7 +58,7 @@ impl<'a> RWops<'a> {
     #[doc(alias = "SDL_RWFromConstMem")]
     pub fn from_bytes(buf: &'a [u8]) -> Result<RWops<'a>, String> {
         let raw =
-            unsafe { sys::SDL_RWFromConstMem(buf.as_ptr() as *const c_void, buf.len() as c_int) };
+            unsafe { sys::SDL_RWFromConstMem(buf.as_ptr() as *const c_void, buf.len()) };
 
         if raw.is_null() {
             Err(get_error())
@@ -92,7 +92,7 @@ impl<'a> RWops<'a> {
     /// This method can only fail if the buffer size is zero.
     #[doc(alias = "SDL_RWFromMem")]
     pub fn from_bytes_mut(buf: &'a mut [u8]) -> Result<RWops<'a>, String> {
-        let raw = unsafe { sys::SDL_RWFromMem(buf.as_ptr() as *mut c_void, buf.len() as c_int) };
+        let raw = unsafe { sys::SDL_RWFromMem(buf.as_ptr() as *mut c_void, buf.len()) };
 
         if raw.is_null() {
             Err(get_error())

--- a/src/sdl3/surface.rs
+++ b/src/sdl3/surface.rs
@@ -289,7 +289,7 @@ impl<'a> Surface<'a> {
 
     #[doc(alias = "SDL_LoadBMP_RW")]
     pub fn load_bmp_rw(rwops: &mut RWops) -> Result<Surface<'static>, String> {
-        let raw = unsafe { sys::SDL_LoadBMP_RW(rwops.raw(), 0) };
+        let raw = unsafe { sys::SDL_LoadBMP_RW(rwops.raw(), sys::SDL_bool::SDL_FALSE) };
 
         if raw.is_null() {
             Err(get_error())

--- a/src/sdl3/timer.rs
+++ b/src/sdl3/timer.rs
@@ -136,12 +136,6 @@ mod test {
     use std::time::Duration;
 
     #[test]
-    fn test_timer() {
-        test_timer_runs_multiple_times();
-        test_timer_runs_at_least_once();
-        test_timer_can_be_recreated();
-    }
-
     fn test_timer_runs_multiple_times() {
         let sdl_context = crate::sdl::init().unwrap();
         let timer_subsystem = sdl_context.timer().unwrap();
@@ -169,8 +163,10 @@ mod test {
         ::std::thread::sleep(Duration::from_millis(250));
         let num = local_num.lock().unwrap(); // read the number back
         assert_eq!(*num, 9); // it should have incremented at least 10 times...
+	sdl_context.sdldrop();
     }
 
+    #[test]
     fn test_timer_runs_at_least_once() {
         let sdl_context = crate::sdl::init().unwrap();
         let timer_subsystem = sdl_context.timer().unwrap();
@@ -192,6 +188,7 @@ mod test {
         assert_eq!(*flag, true);
     }
 
+    #[test]
     fn test_timer_can_be_recreated() {
         let sdl_context = crate::sdl::init().unwrap();
         let timer_subsystem = sdl_context.timer().unwrap();

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -447,11 +447,9 @@ pub mod gl_attr {
 pub struct DisplayMode {
     pub display_id: sys::SDL_DisplayID,
     pub format: PixelFormatEnum,
-    pub screen_w: i32,
-    pub screen_h: i32,
-    pub pixel_w: i32,
-    pub pixel_h: i32,
-    pub display_scale: f32,
+    pub w: i32,
+    pub h: i32,
+    pub pixel_density: f32,
     pub refresh_rate: f32,
 }
 
@@ -459,21 +457,17 @@ impl DisplayMode {
     pub fn new(
         display_id: sys::SDL_DisplayID,
         format: PixelFormatEnum,
-        screen_w: i32,
-        screen_h: i32,
-        pixel_w: i32,
-        pixel_h: i32,
-        display_scale: f32,
+        w: i32,
+        h: i32,
+        pixel_density: f32,
         refresh_rate: f32,
     ) -> DisplayMode {
         DisplayMode {
             display_id,
             format,
-            screen_w,
-            screen_h,
-            pixel_w,
-            pixel_h,
-            display_scale,
+            w,
+            h,
+	    pixel_density,
             refresh_rate,
         }
     }
@@ -482,11 +476,9 @@ impl DisplayMode {
         DisplayMode::new(
             raw.displayID,
             PixelFormatEnum::try_from(raw.format as u32).unwrap_or(PixelFormatEnum::Unknown),
-            raw.screen_w,
-            raw.screen_h,
-            raw.pixel_w,
-            raw.pixel_h,
-            raw.display_scale,
+            raw.w,
+            raw.h,
+            raw.pixel_density,
             raw.refresh_rate,
         )
     }
@@ -495,11 +487,9 @@ impl DisplayMode {
         sys::SDL_DisplayMode {
             displayID: self.display_id,
             format: self.format as u32,
-            screen_w: self.screen_w,
-            screen_h: self.screen_h,
-            pixel_w: self.pixel_w,
-            pixel_h: self.pixel_h,
-            display_scale: self.display_scale,
+            w: self.w,
+            h: self.h,
+            pixel_density: self.pixel_density,
             refresh_rate: self.refresh_rate,
             driverdata: ptr::null_mut(),
         }
@@ -854,13 +844,19 @@ impl VideoSubsystem {
         &self,
         display_index: u32,
         mode: &DisplayMode,
+	include_high_density_modes: bool
     ) -> Result<DisplayMode, String> {
         unsafe {
             let mode = sys::SDL_GetClosestFullscreenDisplayMode(
                 display_index,
-                mode.pixel_w,
-                mode.pixel_h,
+                mode.w,
+                mode.h,
                 mode.refresh_rate,
+		if include_high_density_modes {
+		    sys::SDL_bool::SDL_TRUE
+		} else {
+		    sys::SDL_bool::SDL_FALSE
+		},
             );
             if mode.is_null() {
                 Err(get_error())
@@ -873,7 +869,7 @@ impl VideoSubsystem {
     /// Return orientation of a display or Unknown if orientation could not be determined.
     #[doc(alias = "SDL_GetDisplayOrientation")]
     pub fn display_orientation(&self, display_index: u32) -> Orientation {
-        Orientation::from_ll(unsafe { sys::SDL_GetDisplayOrientation(display_index) })
+        Orientation::from_ll(unsafe { sys::SDL_GetCurrentDisplayOrientation(display_index) })
     }
 
     #[doc(alias = "SDL_ScreenSaverEnabled")]

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,11 +1,11 @@
-extern crate sdl2;
+extern crate sdl3;
 
 #[test]
 fn audio_spec_wav() {
-    let wav = sdl2::audio::AudioSpecWAV::load_wav("./assets/sine.wav").unwrap();
+    let wav = sdl3::audio::AudioSpecWAV::load_wav("./assets/sine.wav").unwrap();
 
     assert_eq!(wav.freq, 22_050);
-    assert_eq!(wav.format, sdl2::audio::AudioFormat::S16LSB);
+    assert_eq!(wav.format, sdl3::audio::AudioFormat::S16LSB);
     assert_eq!(wav.channels, 1);
 
     let buffer = wav.buffer();

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,8 +1,8 @@
-extern crate sdl2;
+extern crate sdl3;
 #[macro_use]
 extern crate lazy_static;
 
-use sdl2::event;
+use sdl3::event;
 use std::sync::Mutex;
 
 // Since only one `Sdl` context instance can be created at a time, running tests in parallel causes
@@ -15,7 +15,7 @@ lazy_static! {
 #[test]
 fn test_events() {
     let _lock = CONTEXT_MUTEX.lock();
-    let sdl = sdl2::init().unwrap();
+    let sdl = sdl3::init().unwrap();
     let ev = sdl.event().unwrap();
     let mut ep = sdl.event_pump().unwrap();
 
@@ -33,13 +33,13 @@ fn test_events() {
     test4(&ev, &mut ep);
 }
 
-fn test1(ev: &sdl2::EventSubsystem) {
+fn test1(ev: &sdl3::EventSubsystem) {
     let user_event1_id = unsafe { ev.register_event().unwrap() };
     let user_event2_id = unsafe { ev.register_event().unwrap() };
     assert_ne!(user_event1_id, user_event2_id);
 }
 
-fn test2(ev: &sdl2::EventSubsystem, ep: &mut sdl2::EventPump) {
+fn test2(ev: &sdl3::EventSubsystem, ep: &mut sdl3::EventPump) {
     let user_event_id = unsafe { ev.register_event().unwrap() };
 
     let event = event::Event::User {
@@ -95,7 +95,7 @@ struct SomeOtherEventTypeTest3 {
     b: u32,
 }
 
-fn test3(ev: &sdl2::EventSubsystem) {
+fn test3(ev: &sdl3::EventSubsystem) {
     ev.register_custom_event::<SomeEventTypeTest3>().unwrap();
     ev.register_custom_event::<SomeOtherEventTypeTest3>()
         .unwrap();
@@ -107,7 +107,7 @@ struct SomeEventTypeTest4 {
     a: u32,
 }
 
-fn test4(ev: &sdl2::EventSubsystem, ep: &mut sdl2::EventPump) {
+fn test4(ev: &sdl3::EventSubsystem, ep: &mut sdl3::EventPump) {
     ev.register_custom_event::<SomeEventTypeTest4>().unwrap();
     let event = SomeEventTypeTest4 { a: 42 };
     ev.push_custom_event(event).unwrap();
@@ -122,15 +122,15 @@ fn test4(ev: &sdl2::EventSubsystem, ep: &mut sdl2::EventPump) {
 #[test]
 fn test_event_sender_no_subsystem() {
     let _lock = CONTEXT_MUTEX.lock();
-    let sdl = sdl2::init().unwrap();
+    let sdl = sdl3::init().unwrap();
     let ev = sdl.event().unwrap();
     let tx = ev.event_sender();
 
     assert!(tx
-        .push_event(sdl2::event::Event::Window {
+        .push_event(sdl3::event::Event::Window {
             timestamp: 0,
             window_id: 0,
-            win_event: sdl2::event::WindowEvent::Shown,
+            win_event: sdl3::event::WindowEvent::Shown,
         })
         .is_ok());
 
@@ -138,10 +138,10 @@ fn test_event_sender_no_subsystem() {
 
     // Should return an error now the evet subsystem has been shut down
     assert!(tx
-        .push_event(sdl2::event::Event::Window {
+        .push_event(sdl3::event::Event::Window {
             timestamp: 0,
             window_id: 0,
-            win_event: sdl2::event::WindowEvent::Hidden,
+            win_event: sdl3::event::WindowEvent::Hidden,
         })
         .is_err());
 }

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "raw-window-handle")]
 mod raw_window_handle_test {
     extern crate raw_window_handle;
-    extern crate sdl2;
+    extern crate sdl3;
 
     use self::raw_window_handle::{
         HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
     };
-    use self::sdl2::video::Window;
+    use self::sdl3::video::Window;
 
     #[cfg(target_os = "windows")]
     #[test]
@@ -115,7 +115,7 @@ mod raw_window_handle_test {
     }
 
     pub fn new_hidden_window() -> Window {
-        let context = sdl2::init().unwrap();
+        let context = sdl3::init().unwrap();
         let video_subsystem = context.video().unwrap();
         video_subsystem
             .window("Hello, World!", 800, 600)

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,8 +1,8 @@
-extern crate sdl2;
+extern crate sdl3;
 
 #[test]
 fn display_name_no_segfault() {
-    let sdl_context = sdl2::init().unwrap();
+    let sdl_context = sdl3::init().unwrap();
     let video_subsystem = sdl_context.video();
     if let Ok(video_subsystem) = video_subsystem {
         // hopefully no one has a 100 screen to see this test pass


### PR DESCRIPTION
This commit fixes numerous build and test failures that pop up when
linking against an updated SDL3-sys that uses recent a recent SDL3
git version (fb68e8464638976e13c6a31eb8d3a7884e4b833e used here).

Note that this version depends on
`https://github.com/Lokathor/sdl3-sys-rs/pull/5` and thus currently references my fork of `sdl3-sys-rs` in `Cargo.toml`.
Let's wait a little for a verdict on that PR before merging.

New feature:
- Feature `test-mode` allows running the integration tests without
  failing the Sdl::init() sanity check; the documentation reflects
  this now.

Missing:
- examples/audio-wav.rs is currently disabled; it needs to be ported
  from AudioCVT (which has been retired) to AudioStream.
- The examples need testing.
- The docs still refer to sdl2 all over the place.
