### PR TITLE
Fixes for `cpuinfo` and `init`

### DIFF
--- a/src/sdl3/cpuinfo.rs
+++ b/src/sdl3/cpuinfo.rs
@@ -62,7 +62,32 @@ pub fn has_avx512f() -> bool {
     unsafe { sys::cpuinfo::SDL_HasAVX512F() }
 }
 
+#[doc(alias = "SDL_HasARMSIMD")]
+pub fn has_arm_simd() -> bool {
+    unsafe { sys::cpuinfo::SDL_HasARMSIMD() }
+}
+
+#[doc(alias = "SDL_HasNEON")]
+pub fn has_neon() -> bool {
+    unsafe { sys::cpuinfo::SDL_HasNEON() }
+}
+
+#[doc(alias = "SDL_HasLSX")]
+pub fn has_lsx() -> bool {
+    unsafe { sys::cpuinfo::SDL_HasLSX() }
+}
+
+#[doc(alias = "SDL_HasLASX")]
+pub fn has_lasx() -> bool {
+    unsafe { sys::cpuinfo::SDL_HasLASX() }
+}
+
 #[doc(alias = "SDL_GetSystemRAM")]
 pub fn system_ram() -> i32 {
     unsafe { sys::cpuinfo::SDL_GetSystemRAM() }
+}
+
+#[doc(alias = "SDL_GetSIMDAlignment")]
+pub fn simd_alignment() -> usize {
+    unsafe { sys::cpuinfo::SDL_GetSIMDAlignment() }
 }

--- a/src/sdl3/cpuinfo.rs
+++ b/src/sdl3/cpuinfo.rs
@@ -3,7 +3,7 @@ use crate::sys;
 pub const CACHELINESIZE: u8 = 128;
 
 #[doc(alias = "SDL_GetNumLogicalCPUCores")]
-pub fn cpu_count() -> i32 {
+pub fn num_logical_cpu_cores() -> i32 {
     unsafe { sys::cpuinfo::SDL_GetNumLogicalCPUCores() }
 }
 
@@ -14,52 +14,52 @@ pub fn cpu_cache_line_size() -> i32 {
 
 #[doc(alias = "SDL_HasAltiVec")]
 pub fn has_alti_vec() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasAltiVec() == true }
+    unsafe { sys::cpuinfo::SDL_HasAltiVec() }
 }
 
 #[doc(alias = "SDL_HasMMX")]
 pub fn has_mmx() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasMMX() == true }
+    unsafe { sys::cpuinfo::SDL_HasMMX() }
 }
 
 #[doc(alias = "SDL_HasSSE")]
 pub fn has_sse() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasSSE() == true }
+    unsafe { sys::cpuinfo::SDL_HasSSE() }
 }
 
 #[doc(alias = "SDL_HasSSE2")]
 pub fn has_sse2() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasSSE2() == true }
+    unsafe { sys::cpuinfo::SDL_HasSSE2() }
 }
 
 #[doc(alias = "SDL_HasSSE3")]
 pub fn has_sse3() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasSSE3() == true }
+    unsafe { sys::cpuinfo::SDL_HasSSE3() }
 }
 
 #[doc(alias = "SDL_HasSSE41")]
 pub fn has_sse41() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasSSE41() == true }
+    unsafe { sys::cpuinfo::SDL_HasSSE41() }
 }
 
 #[doc(alias = "SDL_HasSSE42")]
 pub fn has_sse42() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasSSE42() == true }
+    unsafe { sys::cpuinfo::SDL_HasSSE42() }
 }
 
 #[doc(alias = "SDL_HasAVX")]
 pub fn has_avx() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasAVX() == true }
+    unsafe { sys::cpuinfo::SDL_HasAVX() }
 }
 
 #[doc(alias = "SDL_HasAVX2")]
 pub fn has_avx2() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasAVX2() == true }
+    unsafe { sys::cpuinfo::SDL_HasAVX2() }
 }
 
 #[doc(alias = "SDL_HasAVX512F")]
 pub fn has_avx512f() -> bool {
-    unsafe { sys::cpuinfo::SDL_HasAVX512F() == true }
+    unsafe { sys::cpuinfo::SDL_HasAVX512F() }
 }
 
 #[doc(alias = "SDL_GetSystemRAM")]

--- a/src/sdl3/sdl.rs
+++ b/src/sdl3/sdl.rs
@@ -1,4 +1,5 @@
 use libc::c_char;
+use sys::init::{SDL_INIT_AUDIO, SDL_INIT_CAMERA, SDL_INIT_EVENTS, SDL_INIT_GAMEPAD, SDL_INIT_HAPTIC, SDL_INIT_JOYSTICK, SDL_INIT_SENSOR, SDL_INIT_VIDEO};
 use std::cell::Cell;
 use std::error;
 use std::ffi::{CStr, CString, NulError};
@@ -8,7 +9,7 @@ use std::os::raw::c_void;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use crate::sys;
-use crate::sys::SDL_InitFlags;
+use crate::sys::init::SDL_InitFlags;
 
 #[repr(i32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -312,51 +313,50 @@ impl Drop for SubsystemDrop {
 
 subsystem!(
     AudioSubsystem,
-    SDL_InitFlags::SDL_INIT_AUDIO as u32,
+    SDL_INIT_AUDIO as u32,
     AUDIO_COUNT,
     nosync
 );
 subsystem!(
-    GamepadSubsystem,
-    SDL_InitFlags::SDL_INIT_GAMEPAD as u32,
-    GAMEPAD_COUNT,
-    nosync
-);
-subsystem!(
-    HapticSubsystem,
-    SDL_InitFlags::SDL_INIT_HAPTIC as u32,
-    HAPTIC_COUNT,
+    VideoSubsystem,
+    SDL_INIT_VIDEO as u32,
+    VIDEO_COUNT,
     nosync
 );
 subsystem!(
     JoystickSubsystem,
-    SDL_InitFlags::SDL_INIT_JOYSTICK as u32,
+    SDL_INIT_JOYSTICK as u32,
     JOYSTICK_COUNT,
     nosync
 );
 subsystem!(
-    VideoSubsystem,
-    SDL_InitFlags::SDL_INIT_VIDEO as u32,
-    VIDEO_COUNT,
+    HapticSubsystem,
+    SDL_INIT_HAPTIC as u32,
+    HAPTIC_COUNT,
     nosync
 );
-// Timers can be added on other threads.
 subsystem!(
-    TimerSubsystem,
-    SDL_InitFlags::SDL_INIT_TIMER as u32,
-    TIMER_COUNT,
-    sync
+    GamepadSubsystem,
+    SDL_INIT_GAMEPAD as u32,
+    GAMEPAD_COUNT,
+    nosync
 );
 // The event queue can be read from other threads.
 subsystem!(
     EventSubsystem,
-    SDL_InitFlags::SDL_INIT_EVENTS as u32,
+    SDL_INIT_EVENTS as u32,
     EVENT_COUNT,
     sync
 );
 subsystem!(
     SensorSubsystem,
-    SDL_InitFlags::SDL_INIT_SENSOR as u32,
+    SDL_INIT_SENSOR as u32,
+    SENSOR_COUNT,
+    nosync
+);
+subsystem!(
+    CameraSubsystem,
+    SDL_INIT_CAMERA as u32,
     SENSOR_COUNT,
     nosync
 );

--- a/src/sdl3/sdl.rs
+++ b/src/sdl3/sdl.rs
@@ -357,7 +357,7 @@ subsystem!(
 subsystem!(
     CameraSubsystem,
     SDL_INIT_CAMERA as u32,
-    SENSOR_COUNT,
+    CAMERA_COUNT,
     nosync
 );
 

--- a/src/sdl3/timer.rs
+++ b/src/sdl3/timer.rs
@@ -3,102 +3,96 @@ use libc::c_void;
 use std::marker::PhantomData;
 use std::mem;
 
-use crate::TimerSubsystem;
+/// Constructs a new timer using the boxed closure `callback`.
+///
+/// The timer is started immediately, it will be cancelled either:
+///
+/// * when the timer is dropped
+/// * or when the callback returns a non-positive continuation interval
+///
+/// The callback is run in a thread that is created and managed internally
+/// by SDL2 from C. The callback *must* not panic!
+#[must_use = "if unused the Timer will be dropped immediately"]
+#[doc(alias = "SDL_AddTimer")]
+pub fn add_timer<'c>(delay: u32, callback: TimerCallback<'c>) -> Timer<'c> {
+    unsafe {
+        let callback = Box::new(callback);
+        let timer_id = sys::SDL_AddTimer(
+            delay,
+            Some(c_timer_callback),
+            mem::transmute_copy(&callback),
+        );
 
-impl TimerSubsystem {
-    /// Constructs a new timer using the boxed closure `callback`.
-    ///
-    /// The timer is started immediately, it will be cancelled either:
-    ///
-    /// * when the timer is dropped
-    /// * or when the callback returns a non-positive continuation interval
-    ///
-    /// The callback is run in a thread that is created and managed internally
-    /// by SDL2 from C. The callback *must* not panic!
-    #[must_use = "if unused the Timer will be dropped immediately"]
-    #[doc(alias = "SDL_AddTimer")]
-    pub fn add_timer<'b, 'c>(&'b self, delay: u32, callback: TimerCallback<'c>) -> Timer<'b, 'c> {
-        unsafe {
-            let callback = Box::new(callback);
-            let timer_id = sys::SDL_AddTimer(
-                delay,
-                Some(c_timer_callback),
-                mem::transmute_copy(&callback),
-            );
-
-            Timer {
-                callback: Some(callback),
-                raw: timer_id,
-                _marker: PhantomData,
-            }
+        Timer {
+            callback: Some(callback),
+            raw: timer_id,
         }
     }
+}
 
-    /// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
-    ///
-    /// It's recommended that you use another library for timekeeping, such as `time`.
-    ///
-    /// This function is not recommended in upstream SDL2 as of 2.0.18 and internally
-    /// calls the 64-bit variant and masks the result.
-    #[doc(alias = "SDL_GetTicks")]
-    pub fn ticks(&self) -> u64 {
-        // This is thread-safe as long as the ticks subsystem is inited, and
-        // tying this to `TimerSubsystem` ensures the timer subsystem can
-        // safely make calls into the ticks subsystem without invoking a
-        // thread-unsafe `SDL_TicksInit()`.
-        //
-        // This binding is offered for completeness but is debatably a relic.
-        unsafe { sys::SDL_GetTicks() }
-    }
+/// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
+///
+/// It's recommended that you use another library for timekeeping, such as `time`.
+///
+/// This function is not recommended in upstream SDL2 as of 2.0.18 and internally
+/// calls the 64-bit variant and masks the result.
+#[doc(alias = "SDL_GetTicks")]
+pub fn ticks() -> u64 {
+    // This is thread-safe as long as the ticks subsystem is inited, and
+    // tying this to `TimerSubsystem` ensures the timer subsystem can
+    // safely make calls into the ticks subsystem without invoking a
+    // thread-unsafe `SDL_TicksInit()`.
+    //
+    // This binding is offered for completeness but is debatably a relic.
+    unsafe { sys::SDL_GetTicks() }
+}
 
-    /// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
-    ///
-    /// It's recommended that you use another library for timekeeping, such as `time`.
-    #[doc(alias = "SDL_GetTicks")]
-    pub fn ticks64(&self) -> u64 {
-        // This is thread-safe as long as the ticks subsystem is inited, and
-        // tying this to `TimerSubsystem` ensures the timer subsystem can
-        // safely make calls into the ticks subsystem without invoking a
-        // thread-unsafe `SDL_TicksInit()`.
-        //
-        // This binding is offered for completeness but is debatably a relic.
-        unsafe { sys::SDL_GetTicks() }
-    }
+/// Gets the number of milliseconds elapsed since the timer subsystem was initialized.
+///
+/// It's recommended that you use another library for timekeeping, such as `time`.
+#[doc(alias = "SDL_GetTicks")]
+pub fn ticks64() -> u64 {
+    // This is thread-safe as long as the ticks subsystem is inited, and
+    // tying this to `TimerSubsystem` ensures the timer subsystem can
+    // safely make calls into the ticks subsystem without invoking a
+    // thread-unsafe `SDL_TicksInit()`.
+    //
+    // This binding is offered for completeness but is debatably a relic.
+    unsafe { sys::SDL_GetTicks() }
+}
 
-    /// Sleeps the current thread for the specified amount of milliseconds.
-    ///
-    /// It's recommended that you use `std::thread::sleep()` instead.
-    #[doc(alias = "SDL_Delay")]
-    pub fn delay(&self, ms: u32) {
-        // This is thread-safe as long as the ticks subsystem is inited, and
-        // tying this to `TimerSubsystem` ensures the timer subsystem can
-        // safely make calls into the ticks subsystem without invoking a
-        // thread-unsafe `SDL_TicksInit()`.
-        //
-        // This binding is offered for completeness but is debatably a relic.
-        unsafe { sys::SDL_Delay(ms) }
-    }
+/// Sleeps the current thread for the specified amount of milliseconds.
+///
+/// It's recommended that you use `std::thread::sleep()` instead.
+#[doc(alias = "SDL_Delay")]
+pub fn delay(ms: u32) {
+    // This is thread-safe as long as the ticks subsystem is inited, and
+    // tying this to `TimerSubsystem` ensures the timer subsystem can
+    // safely make calls into the ticks subsystem without invoking a
+    // thread-unsafe `SDL_TicksInit()`.
+    //
+    // This binding is offered for completeness but is debatably a relic.
+    unsafe { sys::SDL_Delay(ms) }
+}
 
-    #[doc(alias = "SDL_GetPerformanceCounter")]
-    pub fn performance_counter(&self) -> u64 {
-        unsafe { sys::SDL_GetPerformanceCounter() }
-    }
+#[doc(alias = "SDL_GetPerformanceCounter")]
+pub fn performance_counter() -> u64 {
+    unsafe { sys::SDL_GetPerformanceCounter() }
+}
 
-    #[doc(alias = "SDL_GetPerformanceFrequency")]
-    pub fn performance_frequency(&self) -> u64 {
-        unsafe { sys::SDL_GetPerformanceFrequency() }
-    }
+#[doc(alias = "SDL_GetPerformanceFrequency")]
+pub fn performance_frequency() -> u64 {
+    unsafe { sys::SDL_GetPerformanceFrequency() }
 }
 
 pub type TimerCallback<'a> = Box<dyn FnMut() -> u32 + 'a + Send>;
 
-pub struct Timer<'b, 'a> {
+pub struct Timer<'a> {
     callback: Option<Box<TimerCallback<'a>>>,
     raw: sys::SDL_TimerID,
-    _marker: PhantomData<&'b ()>,
 }
 
-impl<'b, 'a> Timer<'b, 'a> {
+impl<'a> Timer<'a> {
     /// Returns the closure as a trait-object and cancels the timer
     /// by consuming it...
     pub fn into_inner(mut self) -> TimerCallback<'a> {
@@ -106,7 +100,7 @@ impl<'b, 'a> Timer<'b, 'a> {
     }
 }
 
-impl<'b, 'a> Drop for Timer<'b, 'a> {
+impl<'a> Drop for Timer<'a> {
     #[inline]
     #[doc(alias = "SDL_RemoveTimer")]
     fn drop(&mut self) {


### PR DESCRIPTION
Changes:
- more feature flags for SIMD on ARM and LoongArch
- `SDL_GetCPUCount` renamed to `SDL_GetNumLogicalCPUCores`, changed Rust name to reflect it
- changed subsystems to match available init flags
  - side effect: Timers are no longer under a subsystem. `Timer` thus does not need a lifetime parameter to ensure it doesn't outlive the timer subsystem.