### PR TITLE
RWOps -> IOStream

### DIFF
--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -62,7 +62,7 @@ use std::path::Path;
 use std::ptr;
 
 use crate::get_error;
-use crate::rwops::RWops;
+use crate::iostream::RWops;
 use crate::AudioSubsystem;
 
 use crate::sys;

--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -52,6 +52,9 @@
 //! std::thread::sleep(Duration::from_millis(2000));
 //! ```
 
+use crate::get_error;
+use crate::AudioSubsystem;
+use iostream::IOStream;
 use libc::{c_char, c_int, c_void};
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
@@ -60,10 +63,6 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::ptr;
-
-use crate::get_error;
-use crate::iostream::RWops;
-use crate::AudioSubsystem;
 
 use crate::sys;
 use crate::sys::SDL_AudioStatus;
@@ -388,13 +387,13 @@ pub struct AudioSpecWAV {
 impl AudioSpecWAV {
     /// Loads a WAVE from the file path.
     pub fn load_wav<P: AsRef<Path>>(path: P) -> Result<AudioSpecWAV, String> {
-        let mut file = RWops::from_file(path, "rb")?;
+        let mut file = IOStream::from_file(path, "rb")?;
         AudioSpecWAV::load_wav_rw(&mut file)
     }
 
     /// Loads a WAVE from the data source.
     #[doc(alias = "SDL_LoadWAV_RW")]
-    pub fn load_wav_rw(src: &mut RWops) -> Result<AudioSpecWAV, String> {
+    pub fn load_wav_rw(src: &mut IOStream) -> Result<AudioSpecWAV, String> {
         use std::mem::MaybeUninit;
         use std::ptr::null_mut;
 

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -1,4 +1,4 @@
-use crate::iostream::RWops;
+use crate::iostream::IOStream;
 use libc::{c_char, c_void};
 use std::error;
 use std::ffi::{CStr, CString, NulError};
@@ -14,10 +14,9 @@ use std::convert::TryInto;
 use crate::common::IntegerOrSdlError;
 use crate::get_error;
 use crate::joystick;
+use crate::sys;
 use crate::GamepadSubsystem;
 use std::mem::transmute;
-
-use crate::sys;
 
 #[derive(Debug, Clone)]
 pub enum AddMappingError {
@@ -154,7 +153,7 @@ impl GamepadSubsystem {
     pub fn load_mappings<P: AsRef<Path>>(&self, path: P) -> Result<i32, AddMappingError> {
         use self::AddMappingError::*;
 
-        let rw = RWops::from_file(path, "r").map_err(InvalidFilePath)?;
+        let rw = IOStream::from_file(path, "r").map_err(InvalidFilePath)?;
         self.load_mappings_from_rw(rw)
     }
 
@@ -166,13 +165,13 @@ impl GamepadSubsystem {
         use self::AddMappingError::*;
 
         let mut buffer = Vec::with_capacity(1024);
-        let rw = RWops::from_read(read, &mut buffer).map_err(ReadError)?;
+        let rw = IOStream::from_read(read, &mut buffer).map_err(ReadError)?;
         self.load_mappings_from_rw(rw)
     }
 
-    /// Load controller input mappings from an SDL [`RWops`] object.
+    /// Load controller input mappings from an SDL [`IOStream`] object.
     #[doc(alias = "SDL_AddGamepadMappingsFromIO")]
-    pub fn load_mappings_from_rw<'a>(&self, rw: RWops<'a>) -> Result<i32, AddMappingError> {
+    pub fn load_mappings_from_rw<'a>(&self, rw: IOStream<'a>) -> Result<i32, AddMappingError> {
         use self::AddMappingError::*;
 
         let result = unsafe { sys::gamepad::SDL_AddGamepadMappingsFromIO(rw.raw(), false) };

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -1,4 +1,4 @@
-use crate::rwops::RWops;
+use crate::iostream::RWops;
 use libc::{c_char, c_void};
 use std::error;
 use std::ffi::{CStr, CString, NulError};
@@ -140,7 +140,8 @@ impl GamepadSubsystem {
             Err(err) => return Err(InvalidMapping(err)),
         };
 
-        let result = unsafe { sys::gamepad::SDL_AddGamepadMapping(mapping.as_ptr() as *const c_char) };
+        let result =
+            unsafe { sys::gamepad::SDL_AddGamepadMapping(mapping.as_ptr() as *const c_char) };
 
         match result {
             1 => Ok(MappingStatus::Added),
@@ -330,8 +331,12 @@ impl Button {
             sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_START => Button::Start,
             sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_LEFT_STICK => Button::LeftStick,
             sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_RIGHT_STICK => Button::RightStick,
-            sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_LEFT_SHOULDER => Button::LeftShoulder,
-            sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER => Button::RightShoulder,
+            sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_LEFT_SHOULDER => {
+                Button::LeftShoulder
+            }
+            sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER => {
+                Button::RightShoulder
+            }
             sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_DPAD_UP => Button::DPadUp,
             sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_DPAD_DOWN => Button::DPadDown,
             sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_DPAD_LEFT => Button::DPadLeft,
@@ -357,8 +362,12 @@ impl Button {
             Button::Start => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_START,
             Button::LeftStick => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_LEFT_STICK,
             Button::RightStick => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_RIGHT_STICK,
-            Button::LeftShoulder => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_LEFT_SHOULDER,
-            Button::RightShoulder => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER,
+            Button::LeftShoulder => {
+                sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+            }
+            Button::RightShoulder => {
+                sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+            }
             Button::DPadUp => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_DPAD_UP,
             Button::DPadDown => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_DPAD_DOWN,
             Button::DPadLeft => sys::gamepad::SDL_GamepadButton::SDL_GAMEPAD_BUTTON_DPAD_LEFT,
@@ -502,7 +511,12 @@ impl Gamepad {
         duration_ms: u32,
     ) -> Result<(), IntegerOrSdlError> {
         let result = unsafe {
-            sys::gamepad::SDL_RumbleGamepadTriggers(self.raw, left_rumble, right_rumble, duration_ms)
+            sys::gamepad::SDL_RumbleGamepadTriggers(
+                self.raw,
+                left_rumble,
+                right_rumble,
+                duration_ms,
+            )
         };
 
         if !result {
@@ -516,22 +530,33 @@ impl Gamepad {
     #[doc(alias = "SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN")]
     pub unsafe fn has_led(&self) -> bool {
         let props = sys::gamepad::SDL_GetGamepadProperties(self.raw);
-         sys::properties::SDL_GetBooleanProperty(props, sys::gamepad::SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN.into(), false)
+        sys::properties::SDL_GetBooleanProperty(
+            props,
+            sys::gamepad::SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN.into(),
+            false,
+        )
     }
 
     /// Query whether a game controller has rumble support.
     #[doc(alias = "SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN")]
     pub unsafe fn has_rumble(&self) -> bool {
         let props = sys::gamepad::SDL_GetGamepadProperties(self.raw);
-        sys::properties::SDL_GetBooleanProperty(props, sys::gamepad::SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN.into(), false)
-
+        sys::properties::SDL_GetBooleanProperty(
+            props,
+            sys::gamepad::SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN.into(),
+            false,
+        )
     }
 
     /// Query whether a game controller has rumble support on triggers.
     #[doc(alias = "SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN")]
     pub unsafe fn has_rumble_triggers(&self) -> bool {
-        let props =  sys::gamepad::SDL_GetGamepadProperties(self.raw) ;
-        sys::properties::SDL_GetBooleanProperty(props, sys::gamepad::SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN.into(), false)
+        let props = sys::gamepad::SDL_GetGamepadProperties(self.raw);
+        sys::properties::SDL_GetBooleanProperty(
+            props,
+            sys::gamepad::SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN.into(),
+            false,
+        )
     }
 
     /// Update a game controller's LED color.
@@ -574,8 +599,7 @@ impl Gamepad {
 
     #[doc(alias = "SDL_GamepadSensorEnabled")]
     pub fn sensor_enabled(&self, sensor_type: crate::sensor::SensorType) -> bool {
-      unsafe  { sys::gamepad::SDL_GamepadSensorEnabled(self.raw, sensor_type.into()) }
-
+        unsafe { sys::gamepad::SDL_GamepadSensorEnabled(self.raw, sensor_type.into()) }
     }
 
     #[doc(alias = "SDL_SetGamepadSensorEnabled")]
@@ -588,11 +612,7 @@ impl Gamepad {
             sys::gamepad::SDL_SetGamepadSensorEnabled(
                 self.raw,
                 sensor_type.into(),
-                if enabled {
-                    true
-                } else {
-                    false
-                },
+                if enabled { true } else { false },
             )
         };
 

--- a/src/sdl3/image/mod.rs
+++ b/src/sdl3/image/mod.rs
@@ -21,8 +21,8 @@
 //! ```
 
 use get_error;
+use iostream::RWops;
 use render::{Texture, TextureCreator};
-use rwops::RWops;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::path::Path;

--- a/src/sdl3/image/mod.rs
+++ b/src/sdl3/image/mod.rs
@@ -21,7 +21,7 @@
 //! ```
 
 use get_error;
-use iostream::RWops;
+use iostream::IOStream;
 use render::{Texture, TextureCreator};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
@@ -73,7 +73,7 @@ pub trait LoadSurface: Sized {
 /// Method extensions to Surface for saving to disk
 pub trait SaveSurface {
     fn save<P: AsRef<Path>>(&self, filename: P) -> Result<(), String>;
-    fn save_rw(&self, dst: &mut RWops) -> Result<(), String>;
+    fn save_rw(&self, dst: &mut IOStream) -> Result<(), String>;
 }
 
 impl<'a> LoadSurface for Surface<'a> {
@@ -117,8 +117,8 @@ impl<'a> SaveSurface for Surface<'a> {
         }
     }
 
-    fn save_rw(&self, dst: &mut RWops) -> Result<(), String> {
-        //! Saves an SDL Surface to an RWops
+    fn save_rw(&self, dst: &mut IOStream) -> Result<(), String> {
+        //! Saves an SDL Surface to an IOStream
         unsafe {
             let status = image::IMG_SavePNG_RW(self.raw(), dst.raw(), 0);
 
@@ -214,7 +214,7 @@ fn to_surface_result<'a>(raw: *mut sys::SDL_Surface) -> Result<Surface<'a>, Stri
     }
 }
 
-pub trait ImageRWops {
+pub trait ImageIOStream {
     /// load as a surface. except TGA
     fn load(&self) -> Result<Surface<'static>, String>;
     /// load as a surface. This can load all supported image formats.
@@ -252,7 +252,7 @@ pub trait ImageRWops {
     fn is_webp(&self) -> bool;
 }
 
-impl<'a> ImageRWops for RWops<'a> {
+impl<'a> ImageIOStream for IOStream<'a> {
     fn load(&self) -> Result<Surface<'static>, String> {
         let raw = unsafe { image::IMG_Load_RW(self.raw(), 0) };
         to_surface_result(raw)

--- a/src/sdl3/lib.rs
+++ b/src/sdl3/lib.rs
@@ -49,19 +49,16 @@
 #![crate_type = "lib"]
 #![allow(clippy::cast_lossless, clippy::transmute_ptr_to_ref)]
 
-pub extern crate libc;
-
-#[macro_use]
-extern crate lazy_static;
-
 #[macro_use]
 extern crate bitflags;
-
-pub extern crate sdl3_sys as sys;
-// use sdl3_sys as sys;
-
 #[cfg(feature = "gfx")]
 extern crate c_vec;
+#[macro_use]
+extern crate lazy_static;
+pub extern crate libc;
+pub extern crate sdl3_sys as sys;
+
+// use sdl3_sys as sys;
 
 pub use crate::sdl::*;
 
@@ -75,6 +72,7 @@ pub mod filesystem;
 pub mod gamepad;
 pub mod haptic;
 pub mod hint;
+pub mod iostream;
 pub mod joystick;
 pub mod keyboard;
 pub mod log;
@@ -83,7 +81,6 @@ pub mod mouse;
 pub mod pixels;
 pub mod rect;
 pub mod render;
-pub mod rwops;
 mod sdl;
 #[cfg(feature = "hidapi")]
 pub mod sensor;
@@ -108,6 +105,6 @@ mod common;
 // Export return types and such from the common module.
 pub use crate::common::IntegerOrSdlError;
 
+mod guid;
 #[cfg(feature = "raw-window-handle")]
 pub mod raw_window_handle;
-mod guid;

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -22,9 +22,9 @@
 
 use audio::AudioFormatNum;
 use get_error;
+use iostream::RWops;
 use libc::c_void;
 use libc::{c_double, c_int, c_uint};
-use rwops::RWops;
 use std::borrow::ToOwned;
 use std::convert::TryInto;
 use std::default;
@@ -801,8 +801,12 @@ impl<'a> Music<'a> {
     /// Load music from a static byte buffer.
     #[doc(alias = "SDL_RWFromConstMem")]
     pub fn from_static_bytes(buf: &'static [u8]) -> Result<Music<'static>, String> {
-        let rw =
-            unsafe { sys::SDL_RWFromConstMem(buf.as_ptr() as *const c_void, (buf.len() as c_int).try_into().unwrap() ) };
+        let rw = unsafe {
+            sys::SDL_RWFromConstMem(
+                buf.as_ptr() as *const c_void,
+                (buf.len() as c_int).try_into().unwrap(),
+            )
+        };
 
         if rw.is_null() {
             return Err(get_error());

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -22,7 +22,7 @@
 
 use audio::AudioFormatNum;
 use get_error;
-use iostream::RWops;
+use iostream::IOStream;
 use libc::c_void;
 use libc::{c_double, c_int, c_uint};
 use std::borrow::ToOwned;
@@ -254,7 +254,7 @@ impl Drop for Chunk {
 impl Chunk {
     /// Load file for use as a sample.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Chunk, String> {
-        let raw = unsafe { mixer::Mix_LoadWAV_RW(RWops::from_file(path, "rb")?.raw(), 0) };
+        let raw = unsafe { mixer::Mix_LoadWAV_RW(IOStream::from_file(path, "rb")?.raw(), 0) };
         Self::from_owned_raw(raw)
     }
 
@@ -292,15 +292,15 @@ impl Chunk {
     }
 }
 
-/// Loader trait for `RWops`
-pub trait LoaderRWops<'a> {
+/// Loader trait for `IOStream`
+pub trait LoaderIOStream<'a> {
     /// Load src for use as a sample.
     fn load_wav(&self) -> Result<Chunk, String>;
 
     fn load_music(&'a self) -> Result<Music<'a>, String>;
 }
 
-impl<'a> LoaderRWops<'a> for RWops<'a> {
+impl<'a> LoaderIOStream<'a> for IOStream<'a> {
     /// Load src for use as a sample.
     fn load_wav(&self) -> Result<Chunk, String> {
         let raw = unsafe { mixer::Mix_LoadWAV_RW(self.raw(), 0) };

--- a/src/sdl3/surface.rs
+++ b/src/sdl3/surface.rs
@@ -5,17 +5,16 @@ use std::path::Path;
 use std::rc::Rc;
 
 use crate::get_error;
-use crate::iostream::RWops;
 use crate::pixels;
 use crate::rect::Rect;
 use crate::render::{BlendMode, Canvas};
 use crate::render::{Texture, TextureCreator, TextureValueError};
+use crate::sys;
+use iostream::IOStream;
 use libc::c_int;
 use std::convert::TryFrom;
 use std::mem::transmute;
 use std::ptr;
-
-use crate::sys;
 
 /// Holds a `SDL_Surface`
 ///
@@ -288,8 +287,8 @@ impl<'a> Surface<'a> {
     }
 
     #[doc(alias = "SDL_LoadBMP_RW")]
-    pub fn load_bmp_rw(rwops: &mut RWops) -> Result<Surface<'static>, String> {
-        let raw = unsafe { sys::SDL_LoadBMP_RW(rwops.raw(), sys::SDL_bool::SDL_FALSE) };
+    pub fn load_bmp_rw(iostream: &mut IOStream) -> Result<Surface<'static>, String> {
+        let raw = unsafe { sys::SDL_LoadBMP_RW(iostream.raw(), sys::SDL_bool::SDL_FALSE) };
 
         if raw.is_null() {
             Err(get_error())
@@ -299,7 +298,7 @@ impl<'a> Surface<'a> {
     }
 
     pub fn load_bmp<P: AsRef<Path>>(path: P) -> Result<Surface<'static>, String> {
-        let mut file = RWops::from_file(path, "rb")?;
+        let mut file = IOStream::from_file(path, "rb")?;
         Surface::load_bmp_rw(&mut file)
     }
 
@@ -444,8 +443,8 @@ impl SurfaceRef {
     }
 
     #[doc(alias = "SDL_SaveBMP_RW")]
-    pub fn save_bmp_rw(&self, rwops: &mut RWops) -> Result<(), String> {
-        let ret = unsafe { sys::SDL_SaveBMP_RW(self.raw(), rwops.raw(), 0) };
+    pub fn save_bmp_rw(&self, iostream: &mut Iostream) -> Result<(), String> {
+        let ret = unsafe { sys::SDL_SaveBMP_RW(self.raw(), iostream.raw(), 0) };
         if ret == 0 {
             Ok(())
         } else {
@@ -454,7 +453,7 @@ impl SurfaceRef {
     }
 
     pub fn save_bmp<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
-        let mut file = RWops::from_file(path, "wb")?;
+        let mut file = Iostream::from_file(path, "wb")?;
         self.save_bmp_rw(&mut file)
     }
 

--- a/src/sdl3/surface.rs
+++ b/src/sdl3/surface.rs
@@ -5,11 +5,11 @@ use std::path::Path;
 use std::rc::Rc;
 
 use crate::get_error;
+use crate::iostream::RWops;
 use crate::pixels;
 use crate::rect::Rect;
 use crate::render::{BlendMode, Canvas};
 use crate::render::{Texture, TextureCreator, TextureValueError};
-use crate::rwops::RWops;
 use libc::c_int;
 use std::convert::TryFrom;
 use std::mem::transmute;

--- a/src/sdl3/surface.rs
+++ b/src/sdl3/surface.rs
@@ -443,7 +443,7 @@ impl SurfaceRef {
     }
 
     #[doc(alias = "SDL_SaveBMP_RW")]
-    pub fn save_bmp_rw(&self, iostream: &mut Iostream) -> Result<(), String> {
+    pub fn save_bmp_rw(&self, iostream: &mut IOStream) -> Result<(), String> {
         let ret = unsafe { sys::SDL_SaveBMP_RW(self.raw(), iostream.raw(), 0) };
         if ret == 0 {
             Ok(())
@@ -453,7 +453,7 @@ impl SurfaceRef {
     }
 
     pub fn save_bmp<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
-        let mut file = Iostream::from_file(path, "wb")?;
+        let mut file = IOStream::from_file(path, "wb")?;
         self.save_bmp_rw(&mut file)
     }
 

--- a/src/sdl3/ttf/context.rs
+++ b/src/sdl3/ttf/context.rs
@@ -1,5 +1,5 @@
 use get_error;
-use rwops::RWops;
+use iostream::RWops;
 use std::error;
 use std::fmt;
 use std::io;

--- a/src/sdl3/ttf/context.rs
+++ b/src/sdl3/ttf/context.rs
@@ -1,5 +1,5 @@
 use get_error;
-use iostream::RWops;
+use iostream::IOStream;
 use std::error;
 use std::fmt;
 use std::io;
@@ -46,36 +46,36 @@ impl Sdl2TtfContext {
         internal_load_font_at_index(path, index, point_size)
     }
 
-    /// Loads a font from the given SDL2 rwops object with the given size in
+    /// Loads a font from the given SDL2 iostream object with the given size in
     /// points.
-    pub fn load_font_from_rwops<'ttf, 'r>(
+    pub fn load_font_from_iostream<'ttf, 'r>(
         &'ttf self,
-        rwops: RWops<'r>,
+        iostream: IOStream<'r>,
         point_size: u16,
     ) -> Result<Font<'ttf, 'r>, String> {
-        let raw = unsafe { ttf::TTF_OpenFontRW(rwops.raw(), 0, point_size as c_int) };
+        let raw = unsafe { ttf::TTF_OpenFontRW(iostream.raw(), 0, point_size as c_int) };
         if (raw as *mut ()).is_null() {
             Err(get_error())
         } else {
-            Ok(internal_load_font_from_ll(raw, Some(rwops)))
+            Ok(internal_load_font_from_ll(raw, Some(iostream)))
         }
     }
 
-    /// Loads the font at the given index of the SDL2 rwops object with
+    /// Loads the font at the given index of the SDL2 iostream object with
     /// the given size in points.
-    pub fn load_font_at_index_from_rwops<'ttf, 'r>(
+    pub fn load_font_at_index_from_iostream<'ttf, 'r>(
         &'ttf self,
-        rwops: RWops<'r>,
+        iostream: Iostream<'r>,
         index: u32,
         point_size: u16,
     ) -> Result<Font<'ttf, 'r>, String> {
         let raw = unsafe {
-            ttf::TTF_OpenFontIndexRW(rwops.raw(), 0, point_size as c_int, index as c_long)
+            ttf::TTF_OpenFontIndexRW(iostream.raw(), 0, point_size as c_int, index as c_long)
         };
         if (raw as *mut ()).is_null() {
             Err(get_error())
         } else {
-            Ok(internal_load_font_from_ll(raw, Some(rwops)))
+            Ok(internal_load_font_from_ll(raw, Some(iostream)))
         }
     }
 }

--- a/src/sdl3/ttf/font.rs
+++ b/src/sdl3/ttf/font.rs
@@ -1,5 +1,5 @@
 use get_error;
-use iostream::RWops;
+use iostream::IOStream;
 use pixels::Color;
 use std::error;
 use std::error::Error;
@@ -229,16 +229,16 @@ impl<'f, 'text> PartialRendering<'f, 'text> {
 }
 
 /// A loaded TTF font.
-pub struct Font<'ttf_module, 'rwops> {
+pub struct Font<'ttf_module, 'iostream> {
     raw: *mut ttf::TTF_Font,
-    // RWops is only stored here because it must not outlive
-    // the Font struct, and this RWops should not be used by
+    // Iostream is only stored here because it must not outlive
+    // the Font struct, and this Iostream should not be used by
     // anything else
-    // None means that the RWops is handled by SDL itself,
-    // and Some(rwops) means that the RWops is handled by the Rust
+    // None means that the Iostream is handled by SDL itself,
+    // and Some(iostream) means that the Iostream is handled by the Rust
     // side
     #[allow(dead_code)]
-    rwops: Option<RWops<'rwops>>,
+    iostream: Option<IOStream<'iostream>>,
     #[allow(dead_code)]
     _marker: PhantomData<&'ttf_module ()>,
 }
@@ -267,7 +267,7 @@ pub fn internal_load_font<'ttf, P: AsRef<Path>>(
         } else {
             Ok(Font {
                 raw: raw,
-                rwops: None,
+                iostream: None,
                 _marker: PhantomData,
             })
         }
@@ -275,13 +275,16 @@ pub fn internal_load_font<'ttf, P: AsRef<Path>>(
 }
 
 /// Internally used to load a font (for internal visibility).
-pub fn internal_load_font_from_ll<'ttf, 'r, R>(raw: *mut ttf::TTF_Font, rwops: R) -> Font<'ttf, 'r>
+pub fn internal_load_font_from_ll<'ttf, 'r, R>(
+    raw: *mut ttf::TTF_Font,
+    iostream: R,
+) -> Font<'ttf, 'r>
 where
-    R: Into<Option<RWops<'r>>>,
+    R: Into<Option<Iostream<'r>>>,
 {
     Font {
         raw: raw,
-        rwops: rwops.into(),
+        iostream: iostream.into(),
         _marker: PhantomData,
     }
 }
@@ -300,7 +303,7 @@ pub fn internal_load_font_at_index<'ttf, P: AsRef<Path>>(
         } else {
             Ok(Font {
                 raw: raw,
-                rwops: None,
+                iostream: None,
                 _marker: PhantomData,
             })
         }

--- a/src/sdl3/ttf/font.rs
+++ b/src/sdl3/ttf/font.rs
@@ -1,6 +1,6 @@
 use get_error;
+use iostream::RWops;
 use pixels::Color;
-use rwops::RWops;
 use std::error;
 use std::error::Error;
 use std::ffi::NulError;


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_rwopsh

SDL_rwops.h is now named SDL_iostream.h

SDL_RWops is now an opaque structure, and has been renamed to SDL_IOStream. The SDL3 APIs to create an SDL_IOStream (SDL_IOFromFile, etc) are renamed but otherwise still function as they did in SDL2. However, to make a custom SDL_IOStream with app-provided function pointers, call SDL_OpenIO and provide the function pointers through there. To call into an SDL_IOStream's functionality, use the standard APIs (SDL_ReadIO, etc), as the function pointers are internal.

