### PR TITLE
Touch

### DIFF
--- a/src/sdl3/touch.rs
+++ b/src/sdl3/touch.rs
@@ -1,30 +1,22 @@
 use crate::sys;
 
-pub type Finger = sys::SDL_Finger;
-pub type TouchDevice = sys::SDL_TouchID;
+pub type Finger = sys::touch::SDL_Finger;
+pub type TouchId = sys::touch::SDL_TouchID;
 
-#[doc(alias = "SDL_GetNumTouchDevices")]
-pub fn num_touch_devices() -> i32 {
-    unsafe { sys::SDL_GetNumTouchDevices() }
+/// Get a list of registered touch devices.
+#[doc(alias = "SDL_GetTouchDevices")]
+pub fn num_touch_devices() -> Vec<TouchId> {
+    let mut count = 0;
+    let ids = unsafe { sys::touch::SDL_GetTouchDevices(&mut count) };
+
+    (0..count).map(|i| ids[i]).collect()
 }
 
-#[doc(alias = "SDL_GetTouchDevice")]
-pub fn touch_device(index: i32) -> TouchDevice {
-    unsafe { sys::SDL_GetTouchDevice(index) }
-}
-
-#[doc(alias = "SDL_GetNumTouchFingers")]
-pub fn num_touch_fingers(touch: TouchDevice) -> i32 {
-    unsafe { sys::SDL_GetNumTouchFingers(touch) }
-}
-
-#[doc(alias = "SDL_GetTouchFinger")]
-pub fn touch_finger(touch: TouchDevice, index: i32) -> Option<Finger> {
-    let raw = unsafe { sys::SDL_GetTouchFinger(touch, index) };
-
-    if raw.is_null() {
-        None
-    } else {
-        unsafe { Some(*raw) }
+#[doc(alias = "SDL_GetTouchFingers")]
+pub fn num_touch_fingers(touch: TouchId) -> i32 {
+    let mut count = 0;
+    unsafe {
+        sys::touch::SDL_GetTouchFingers(touch, &mut count);
     }
+    count
 }


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_touchh

SDL_GetTouchName is replaced with SDL_GetTouchDeviceName(), which takes an SDL_TouchID instead of an index.

SDL_TouchID and SDL_FingerID are now Uint64 with 0 being an invalid value.

Rather than iterating over touch devices using an index, there is a new function SDL_GetTouchDevices() to get the available devices.

Rather than iterating over touch fingers using an index, there is a new function SDL_GetTouchFingers() to get the current set of active fingers.

The following functions have been removed:

SDL_GetNumTouchDevices() - replaced with SDL_GetTouchDevices()
SDL_GetNumTouchFingers() - replaced with SDL_GetTouchFingers()
SDL_GetTouchDevice() - replaced with SDL_GetTouchDevices()
SDL_GetTouchFinger() - replaced with SDL_GetTouchFingers()