### PR TITLE
Change flags_cstr to a new value used in SDL3

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1190,7 +1190,7 @@ impl WindowBuilder {
                 sys::video::SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER,
                 raw_height.into(),
             );
-            let flags_cstr = CString::new("flags").unwrap();
+            let flags_cstr = CString::new("SDL.window.create.flags").unwrap();
             SDL_SetNumberProperty(props, flags_cstr.as_ptr(), self.window_flags.into());
 
             let raw = sys::video::SDL_CreateWindowWithProperties(props);


### PR DESCRIPTION
I open this PR because I have not been able to build a window with the OpenGL flag, after compiling the latest code from https://github.com/libsdl-org/SDL.

After debugging the issue it seems that the SDL team has changed the key in the props object of the `SDL_CreateWindowWithProperties` function from `flags` to `SDL.window.create.flags`.

This is is the line of the original change: https://github.com/libsdl-org/SDL/commit/d7b027a241b2359f6110cec2aaea2081e1ed3a7c#diff-06371e79a6d9ba5b002debcf820f60d987e85ddec4350391ec343624ee8ebaf2L1372

(the string has since been moved to SDL_video.h (https://github.com/libsdl-org/SDL/blob/main/include/SDL3/SDL_video.h#L1152)

With this change, I'm able to build an OpenGL window again.