### PR TITLE
Update raw-window-handle-with-wgpu to use new WindowEvent::PixelSizeChanged event.

### DIFF
--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), String> {
             match event {
                 Event::Window {
                     window_id,
-                    win_event: WindowEvent::SizeChanged(width, height),
+                    win_event: WindowEvent::PixelSizeChanged(width, height),
                     ..
                 } if window_id == window.id() => {
                     config.width = width as u32;


### PR DESCRIPTION
Now compiles, but fails at linking due to undefined references in sdl3-sys.