### PR TITLE
Add a new feature to use sdl3-sys/sdl-unix-console-build feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ static-link = ["sdl3-sys/link-static"]
 link-framework = ["sdl3-sys/link-framework"]
 build-from-source = ["sdl3-sys/build-from-source"]
 build-from-source-static = ["sdl3-sys/build-from-source-static"]
+build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 
 unsafe_textures = []
 default = []


### PR DESCRIPTION
This is needed to build without X11 support in SDL.

Fixes #41.