### PR TITLE
Fix raw-window-handle & many other compilation errors

### DIFF
--- a/examples/audio-capture-and-replay.rs
+++ b/examples/audio-capture-and-replay.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpecDesired};
+use sdl3::audio::{AudioCallback, AudioSpec};
 use sdl3::AudioSubsystem;
 use std::i16;
 use std::sync::mpsc;
@@ -17,9 +17,7 @@ struct Recording {
 
 // Append the input of the callback to the record_buffer.
 // When the record_buffer is full, send it to the main thread via done_sender.
-impl AudioCallback for Recording {
-    type Channel = i16;
-
+impl AudioCallback<i16> for Recording {
     fn callback(&mut self, input: &mut [i16]) {
         if self.done {
             return;
@@ -41,7 +39,7 @@ impl AudioCallback for Recording {
 
 fn record(
     audio_subsystem: &AudioSubsystem,
-    desired_spec: &AudioSpecDesired,
+    desired_spec: &AudioSpec,
 ) -> Result<Vec<i16>, String> {
     println!(
         "Capturing {:} seconds... Please rock!",
@@ -50,31 +48,28 @@ fn record(
 
     let (done_sender, done_receiver) = mpsc::channel();
 
-    let capture_device = audio_subsystem.open_capture(None, desired_spec, |spec| {
-        println!("Capture Spec = {:?}", spec);
-        Recording {
-            record_buffer: vec![
-                0;
-                spec.freq as usize
-                    * RECORDING_LENGTH_SECONDS
-                    * spec.channels as usize
-            ],
-            pos: 0,
-            done_sender,
-            done: false,
-        }
+    let capture_device = audio_subsystem.open_recording_stream(desired_spec, Recording {
+        record_buffer: vec![
+            0;
+            desired_spec.freq.unwrap() as usize
+                * RECORDING_LENGTH_SECONDS
+                * desired_spec.channels.unwrap() as usize
+        ],
+        pos: 0,
+        done_sender,
+        done: false,
     })?;
 
     println!(
         "AudioDriver: {:?}",
-        capture_device.subsystem().current_audio_driver()
+        audio_subsystem.current_audio_driver()
     );
-    capture_device.resume();
+    capture_device.resume()?;
 
     // Wait until the recording is done.
     let recorded_vec = done_receiver.recv().map_err(|e| e.to_string())?;
 
-    capture_device.pause();
+    capture_device.pause()?;
 
     // Device is automatically closed when dropped.
     // Depending on your system it might be even important that the capture_device is dropped
@@ -104,9 +99,7 @@ struct SoundPlayback {
     pos: usize,
 }
 
-impl AudioCallback for SoundPlayback {
-    type Channel = i16;
-
+impl AudioCallback<i16> for SoundPlayback {
     fn callback(&mut self, out: &mut [i16]) {
         for dst in out.iter_mut() {
             *dst = *self.data.get(self.pos).unwrap_or(&0);
@@ -117,21 +110,18 @@ impl AudioCallback for SoundPlayback {
 
 fn replay_recorded_vec(
     audio_subsystem: &AudioSubsystem,
-    desired_spec: &AudioSpecDesired,
+    desired_spec: &AudioSpec,
     recorded_vec: Vec<i16>,
 ) -> Result<(), String> {
     println!("Playing...");
 
-    let playback_device = audio_subsystem.open_playback(None, desired_spec, |spec| {
-        println!("Playback Spec = {:?}", spec);
-        SoundPlayback {
-            data: recorded_vec,
-            pos: 0,
-        }
+    let playback_device = audio_subsystem.open_playback_stream(desired_spec, SoundPlayback {
+        data: recorded_vec,
+        pos: 0,
     })?;
 
     // Start playback
-    playback_device.resume();
+    playback_device.resume()?;
 
     std::thread::sleep(Duration::from_secs(RECORDING_LENGTH_SECONDS as u64));
     // Device is automatically closed when dropped
@@ -143,10 +133,10 @@ fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
-    let desired_spec = AudioSpecDesired {
+    let desired_spec = AudioSpec {
         freq: None,
         channels: None,
-        samples: None,
+        format: None,
     };
 
     let recorded_vec = record(&audio_subsystem, &desired_spec)?;

--- a/examples/audio-queue-squarewave.rs
+++ b/examples/audio-queue-squarewave.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::AudioSpecDesired;
+use sdl3::audio::AudioSpec;
 
 use std::time::Duration;
 
@@ -21,15 +21,17 @@ fn gen_wave(bytes_to_write: i32) -> Vec<i16> {
     result
 }
 
+// FIXME
+fn main() -> () {}
+#[cfg(feature = "")]
 fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
-    let desired_spec = AudioSpecDesired {
+    let desired_spec = AudioSpec {
         freq: Some(48_000),
         channels: Some(2),
-        // mono  -
-        samples: None, // default sample size
+        format: None,
     };
 
     let device = audio_subsystem.open_queue::<i16, _>(None, &desired_spec)?;

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpecDesired};
+use sdl3::audio::{AudioCallback, AudioSpec};
 use std::time::Duration;
 
 struct SquareWave {
@@ -9,9 +9,7 @@ struct SquareWave {
     volume: f32,
 }
 
-impl AudioCallback for SquareWave {
-    type Channel = f32;
-
+impl AudioCallback<f32> for SquareWave {
     fn callback(&mut self, out: &mut [f32]) {
         // Generate a square wave
         for x in out.iter_mut() {
@@ -29,26 +27,20 @@ fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
-    let desired_spec = AudioSpecDesired {
+    let desired_spec = AudioSpec {
         freq: Some(44_100),
         channels: Some(1), // mono
-        samples: None,     // default sample size
+        format: None,
     };
 
-    let device = audio_subsystem.open_playback(None, &desired_spec, |spec| {
-        // Show obtained AudioSpec
-        println!("{:?}", spec);
-
-        // initialize the audio callback
-        SquareWave {
-            phase_inc: 440.0 / spec.freq as f32,
-            phase: 0.0,
-            volume: 0.25,
-        }
+    let device = audio_subsystem.open_playback_stream(&desired_spec, SquareWave {
+        phase_inc: 440.0 / desired_spec.freq.unwrap() as f32,
+        phase: 0.0,
+        volume: 0.25,
     })?;
 
     // Start playback
-    device.resume();
+    device.resume()?;
 
     // Play for 2 seconds
     std::thread::sleep(Duration::from_millis(2_000));

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpecDesired, AudioSpecWAV};
+use sdl3::audio::{AudioCallback, AudioSpec, AudioSpecWAV};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -14,9 +14,7 @@ struct Sound {
     pos: usize,
 }
 
-impl AudioCallback for Sound {
-    type Channel = u8;
-
+impl AudioCallback<u8> for Sound {
     fn callback(&mut self, out: &mut [u8]) {
         for dst in out.iter_mut() {
             // With channel type u8 the "silence" value is 128 (middle of the 0-2^8 range) so we need

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,22 +1,21 @@
 extern crate rand;
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpecDesired};
-use std::time::Duration;
+use sdl3::audio::{AudioCallback, AudioSpec};
+use std::{sync::{Arc, Mutex}, time::Duration};
 
 struct MyCallback {
-    volume: f32,
+    volume: Arc<Mutex<f32>>, // it seems like AudioStreamWithCallback<> is supposed to have a lock() method which allows us to modify MyCallback, but that function no longer seems to exist
 }
-impl AudioCallback for MyCallback {
-    type Channel = f32;
-
+impl AudioCallback<f32> for MyCallback {
     fn callback(&mut self, out: &mut [f32]) {
         use self::rand::{thread_rng, Rng};
         let mut rng = thread_rng();
 
+        let Ok(volume) = self.volume.lock() else {return};
         // Generate white noise
         for x in out.iter_mut() {
-            *x = (rng.gen_range(0.0, 2.0) - 1.0) * self.volume;
+            *x = (rng.gen_range(0.0, 2.0) - 1.0) * *volume;
         }
     }
 }
@@ -25,31 +24,25 @@ fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
-    let desired_spec = AudioSpecDesired {
+    let desired_spec = AudioSpec {
         freq: Some(44_100),
         channels: Some(1), // mono
-        samples: None,     // default sample size
+        format: None,
     };
+    let device = audio_subsystem.open_playback_device(&desired_spec)?;
 
     // None: use default device
-    let mut device = audio_subsystem.open_playback(None, &desired_spec, |spec| {
-        // Show obtained AudioSpec
-        println!("{:?}", spec);
-
-        MyCallback { volume: 0.5 }
-    })?;
+    let volume = Arc::new(Mutex::new(0.5));
+    let device = audio_subsystem.open_playback_stream_with_callback(&device, &desired_spec, MyCallback { volume: volume.clone() })?;
 
     // Start playback
-    device.resume();
+    device.resume()?;
 
     // Play for 1 second
     std::thread::sleep(Duration::from_millis(1_000));
 
-    {
-        // Acquire a lock. This lets us read and modify callback data.
-        let mut lock = device.lock();
-        (*lock).volume = 0.25;
-        // Lock guard is dropped here
+    if let Ok(mut volume) = volume.lock() {
+        *volume = 0.25;
     }
 
     // Play for another second

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -16,7 +16,7 @@ pub fn main() -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
 
     canvas.set_draw_color(Color::RGB(255, 0, 0));
     canvas.clear();

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -4,7 +4,7 @@ use sdl3::dialog::{show_open_file_dialog, show_open_folder_dialog, show_save_fil
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 pub fn main() -> Result<(), String> {

--- a/examples/gfx-demo.rs
+++ b/examples/gfx-demo.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
 
     canvas.set_draw_color(pixels::Color::RGB(0, 0, 0));
     canvas.clear();

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -1,3 +1,5 @@
+use sdl3::get_error;
+
 extern crate sdl3;
 
 fn main() -> Result<(), String> {
@@ -11,9 +13,8 @@ fn main() -> Result<(), String> {
     println!("{} joysticks available", joysticks.len());
 
     // Iterate over all available joysticks and stop once we manage to open one.
-    let mut joystick = joysticks
-        .iter()
-        .find_map(|joystick_instance| match joystick_subsystem.open(*joystick_instance.id) {
+    let mut joystick = joysticks.into_iter()
+        .find_map(|joystick| match joystick_subsystem.open(joystick) {
             Ok(c) => {
                 println!("Success: opened \"{}\"", c.name());
                 Some(c)
@@ -59,12 +60,13 @@ fn main() -> Result<(), String> {
                     hi_freq = 65535;
                 }
                 if button_idx < 2 {
-                    match joystick.set_rumble(lo_freq, hi_freq, 15000) {
-                        Ok(()) => println!("Set rumble to ({}, {})", lo_freq, hi_freq),
-                        Err(e) => println!(
+                    if joystick.set_rumble(lo_freq, hi_freq, 15000) {
+                        println!("Set rumble to ({}, {})", lo_freq, hi_freq);
+                    } else {
+                        println!(
                             "Error setting rumble to ({}, {}): {:?}",
-                            lo_freq, hi_freq, e
-                        ),
+                            lo_freq, hi_freq, get_error()
+                        );
                     }
                 }
             }
@@ -76,12 +78,13 @@ fn main() -> Result<(), String> {
                     hi_freq = 0;
                 }
                 if button_idx < 2 {
-                    match joystick.set_rumble(lo_freq, hi_freq, 15000) {
-                        Ok(()) => println!("Set rumble to ({}, {})", lo_freq, hi_freq),
-                        Err(e) => println!(
+                    if joystick.set_rumble(lo_freq, hi_freq, 15000) {
+                        println!("Set rumble to ({}, {})", lo_freq, hi_freq);
+                    } else {
+                        println!(
                             "Error setting rumble to ({}, {}): {:?}",
-                            lo_freq, hi_freq, e
-                        ),
+                            lo_freq, hi_freq, get_error()
+                        );
                     }
                 }
             }

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -2,6 +2,7 @@ extern crate sdl3;
 
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
+use sdl3_sys::keycode::SDL_KMOD_NONE;
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -30,7 +31,7 @@ pub fn main() -> Result<(), String> {
         let keys = events
             .keyboard_state()
             .pressed_scancodes()
-            .filter_map(Keycode::from_scancode)
+            .filter_map(|scancode| Keycode::from_scancode(scancode, SDL_KMOD_NONE, false))
             .collect();
 
         // Get the difference between the new and old sets.

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -16,7 +16,7 @@ pub fn main() -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
 
     canvas.set_draw_color(Color::RGB(255, 0, 0));
     canvas.clear();

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -1,4 +1,5 @@
 /// Minimal example for getting sdl3 and wgpu working together with raw-window-handle.
+/// For your own code, make sure to add "raw-window-handle" to the features list of sdl3
 extern crate pollster;
 extern crate sdl3;
 extern crate wgpu;

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -2,8 +2,9 @@ extern crate sdl3;
 
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
-use sdl3::pixels::{Color, PixelFormatEnum};
+use sdl3::pixels::{Color, PixelFormat};
 use sdl3::render::{FPoint, FRect};
+use sdl3_sys::pixels::SDL_PixelFormat;
 
 fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
@@ -13,14 +14,10 @@ fn main() -> Result<(), String> {
         .position_centered()
         .build()
         .map_err(|e| e.to_string())?;
-    let mut canvas = window
-        .into_canvas()
-        .software()
-        .build()
-        .map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
     let creator = canvas.texture_creator();
     let mut texture = creator
-        .create_texture_target(PixelFormatEnum::RGBA8888, 400, 300)
+        .create_texture_target(unsafe {PixelFormat::from_ll(SDL_PixelFormat::RGBA8888)}, 400, 300)
         .map_err(|e| e.to_string())?;
 
     let mut angle = 0.0;

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -2,8 +2,9 @@ extern crate sdl3;
 
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
-use sdl3::pixels::PixelFormatEnum;
+use sdl3::pixels::PixelFormat;
 use sdl3::render::FRect;
+use sdl3_sys::pixels::SDL_PixelFormat;
 
 pub fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
@@ -16,11 +17,11 @@ pub fn main() -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
     let texture_creator = canvas.texture_creator();
 
     let mut texture = texture_creator
-        .create_texture_streaming(PixelFormatEnum::RGB24, 256, 256)
+        .create_texture_streaming(unsafe {PixelFormat::from_ll(SDL_PixelFormat::RGB24)}, 256, 256)
         .map_err(|e| e.to_string())?;
     // Create a red-green gradient
     texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -2,8 +2,9 @@ extern crate sdl3;
 
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
-use sdl3::pixels::PixelFormatEnum;
+use sdl3::pixels::PixelFormat;
 use sdl3::render::FRect;
+use sdl3_sys::pixels::SDL_PixelFormat;
 
 pub fn main() -> Result<(), String> {
     let sdl_context = sdl3::init()?;
@@ -16,11 +17,11 @@ pub fn main() -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
     let texture_creator = canvas.texture_creator();
 
     let mut texture = texture_creator
-        .create_texture_streaming(PixelFormatEnum::IYUV, 256, 256)
+        .create_texture_streaming(unsafe {PixelFormat::from_ll(SDL_PixelFormat::IYUV)}, 256, 256)
         .map_err(|e| e.to_string())?;
     // Create a U-V gradient
     texture.with_lock(None, |buffer: &mut [u8], pitch: usize| {

--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -55,7 +55,7 @@ fn run(font_path: &Path) -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window.into_canvas().build().map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
     let texture_creator = canvas.texture_creator();
 
     // Load a font

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -14,11 +14,12 @@ pub fn main() -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window
-        .into_canvas()
-        .present_vsync()
-        .build()
-        .map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
+    //let mut canvas = window
+    //    .into_canvas()
+    //    .present_vsync()
+    //    .build()
+    //    .map_err(|e| e.to_string())?;
 
     let mut tick = 0;
 

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -4,7 +4,7 @@ Event Handling
 
 use std::borrow::ToOwned;
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::iter::FromIterator;
 use std::marker::PhantomData;

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -12,20 +12,20 @@ unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {
         // Windows
         #[cfg(target_os = "windows")]
-        {
+        unsafe {
             use self::raw_window_handle::Win32WindowHandle;
             let mut handle = Win32WindowHandle::empty();
 
             let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-            handle.hwnd = sys::video::SDL_GetPointerProperty(
+            handle.hwnd = SDL_GetPointerProperty(
                 window_properties,
                 sys::video::SDL_PROP_WINDOW_WIN32_HWND_POINTER,
                 std::ptr::null_mut(),
             ) as *mut libc::c_void;
-            handle.hinstance = sys::video::SDL_GetPointerProperty(
+            handle.hinstance = SDL_GetPointerProperty(
                 window_properties,
-                sys::video::SDL_PROP_WINDOW_WIN32_HINSTANCE_POINTER,
+                sys::video::SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER,
                 std::ptr::null_mut(),
             ) as *mut libc::c_void;
 
@@ -57,7 +57,7 @@ unsafe impl HasRawWindowHandle for Window {
 
             let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-            handle.ui_window = sys::video::SDL_GetPointerProperty(
+            handle.ui_window = SDL_GetPointerProperty(
                 window_properties,
                 sys::video::SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER,
                 std::ptr::null_mut(),
@@ -75,7 +75,7 @@ unsafe impl HasRawWindowHandle for Window {
 
             let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-            handle.a_native_window = sys::video::SDL_GetPointerProperty(
+            handle.a_native_window = SDL_GetPointerProperty(
                 window_properties,
                 sys::video::SDL_PROP_WINDOW_ANDROID_NATIVE_WINDOW_POINTER,
                 std::ptr::null_mut(),
@@ -101,7 +101,7 @@ unsafe impl HasRawWindowHandle for Window {
 
                     let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-                    handle.display = sys::video::SDL_GetPointerProperty(
+                    handle.display = SDL_GetPointerProperty(
                         window_properties,
                         sys::video::SDL_PROP_WINDOW_X11_DISPLAY_POINTER,
                         std::ptr::null_mut(),
@@ -120,12 +120,12 @@ unsafe impl HasRawWindowHandle for Window {
 
                     let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-                    handle.display = sys::video::SDL_GetPointerProperty(
+                    handle.display = SDL_GetPointerProperty(
                         window_properties,
                         sys::video::SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER,
                         std::ptr::null_mut(),
                     ) as *mut libc::c_void;
-                    handle.surface = sys::video::SDL_GetPointerProperty(
+                    handle.surface = SDL_GetPointerProperty(
                         window_properties,
                         sys::video::SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER,
                         std::ptr::null_mut(),
@@ -182,7 +182,7 @@ unsafe impl HasRawDisplayHandle for Window {
 
             let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-            handle.a_native_window = sys::video::SDL_GetPointerProperty(
+            handle.a_native_window = SDL_GetPointerProperty(
                 window_properties,
                 sys::video::SDL_PROP_WINDOW_ANDROID_NATIVE_WINDOW_POINTER,
                 std::ptr::null_mut(),
@@ -208,7 +208,7 @@ unsafe impl HasRawDisplayHandle for Window {
 
                     let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-                    handle.display = sys::video::SDL_GetPointerProperty(
+                    handle.display = SDL_GetPointerProperty(
                         window_properties,
                         sys::video::SDL_PROP_WINDOW_X11_DISPLAY_POINTER,
                         std::ptr::null_mut(),
@@ -222,7 +222,7 @@ unsafe impl HasRawDisplayHandle for Window {
 
                     let window_properties = sys::video::SDL_GetWindowProperties(self.raw());
 
-                    handle.display = sys::video::SDL_GetPointerProperty(
+                    handle.display = SDL_GetPointerProperty(
                         window_properties,
                         sys::video::SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER,
                         std::ptr::null_mut(),

--- a/src/sdl3/sdl.rs
+++ b/src/sdl3/sdl.rs
@@ -88,12 +88,12 @@ impl Sdl {
         IS_MAIN_THREAD.with(|is_main_thread| {
             if was_main_thread_declared {
                 if !is_main_thread.get() {
-		    // Since 'cargo test' runs its tests in a separate thread, we must disable
-		    // this safety check during testing.
-		    if !(cfg!(test) || cfg!(feature = "test-mode")) {
-			return Err("Cannot initialize `Sdl` from a thread other than the main thread.  For testing, you can disable this check with the feature 'test-mode'.".to_owned());
+            // Since 'cargo test' runs its tests in a separate thread, we must disable
+            // this safety check during testing.
+            if !(cfg!(test) || cfg!(feature = "test-mode")) {
+            return Err("Cannot initialize `Sdl` from a thread other than the main thread.  For testing, you can disable this check with the feature 'test-mode'.".to_owned());
                     }
-		}
+        }
             } else {
                 is_main_thread.set(true);
             }

--- a/src/sdl3/timer.rs
+++ b/src/sdl3/timer.rs
@@ -109,10 +109,12 @@ mod test {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
+    use crate::timer::add_timer;
+
     #[test]
     fn test_timer_runs_multiple_times() {
         let sdl_context = crate::sdl::init().unwrap();
-        let timer_subsystem = sdl_context.timer().unwrap();
+        //let timer_subsystem = sdl_context.timer().unwrap();
 
         let local_num = Arc::new(Mutex::new(0));
         let timer_num = local_num.clone();
@@ -138,7 +140,7 @@ mod test {
     #[test]
     fn test_timer_runs_at_least_once() {
         let sdl_context = crate::sdl::init().unwrap();
-        let timer_subsystem = sdl_context.timer().unwrap();
+        //let timer_subsystem = sdl_context.timer().unwrap();
 
         let local_flag = Arc::new(Mutex::new(false));
         let timer_flag = local_flag.clone();
@@ -160,7 +162,7 @@ mod test {
     #[test]
     fn test_timer_can_be_recreated() {
         let sdl_context = crate::sdl::init().unwrap();
-        let timer_subsystem = sdl_context.timer().unwrap();
+        //let timer_subsystem = sdl_context.timer().unwrap();
 
         let local_num = Arc::new(Mutex::new(0));
         let timer_num = local_num.clone();

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -5,7 +5,7 @@ fn audio_spec_wav() {
     let wav = sdl3::audio::AudioSpecWAV::load_wav("./assets/sine.wav").unwrap();
 
     assert_eq!(wav.freq, 22_050);
-    assert_eq!(wav.format, sdl3::audio::AudioFormat::S16LSB);
+    assert_eq!(wav.format, sdl3::audio::AudioFormat::S16LE);
     assert_eq!(wav.channels, 1);
 
     let buffer = wav.buffer();


### PR DESCRIPTION
Fix every compilation error I have on windows, including raw-window-handle features.

Biggest problems I can see:
- Example audio-queue-squarewave has effecively been removed (using cfg)
- Example audio-whitespace now uses an Arc<Mutex<>>