### PR TITLE
[Experimental] Update to latest wgpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "sdl3"
 description = "Cross-platform multimedia"
 repository = "https://github.com/revmischa/sdl3-rs"
 documentation = "https://docs.rs/sdl3/latest/sdl3/"
-version = "0.11.9"
+version = "0.11.10"
 license = "MIT"
 authors = [
     "Tony Aldridge <tony@angry-lawyer.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "sdl3"
 description = "Cross-platform multimedia"
 repository = "https://github.com/revmischa/sdl3-rs"
 documentation = "https://docs.rs/sdl3/latest/sdl3/"
-version = "0.11.10"
+version = "0.11.9"
 license = "MIT"
 authors = [
     "Tony Aldridge <tony@angry-lawyer.com>",
@@ -36,12 +36,12 @@ optional = true
 
 [dev-dependencies]
 rand = "0.7"
-wgpu = { version = "0.14", features = ["spirv"] }
+wgpu = { version = "23.0.1", features = ["spirv"] }
 pollster = "0.2.4"
 env_logger = "0.9.0"
 
 [dependencies.raw-window-handle]
-version = "0.5.0"
+version = "0.6.2"
 optional = true
 
 [features]

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -47,6 +47,12 @@ fn main() -> Result<(), String> {
         Err(e) => return Err(e.to_string()),
     };
 
+    let capabilities = surface.get_capabilities(&adapter);
+    let mut formats = capabilities.formats;
+    let main_format = *formats.iter()
+        .find(|format| format.is_srgb())
+        .unwrap_or(&formats[0]);
+
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("shader"),
         source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
@@ -77,7 +83,7 @@ fn main() -> Result<(), String> {
         },
         fragment: Some(wgpu::FragmentState {
             targets: &[Some(wgpu::ColorTargetState {
-                format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                format: main_format,
                 blend: None,
                 write_mask: wgpu::ColorWrites::ALL,
             })],
@@ -107,7 +113,7 @@ fn main() -> Result<(), String> {
 
     let mut config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        format: main_format,
         width,
         height,
         present_mode: wgpu::PresentMode::Fifo,

--- a/src/sdl3/render.rs
+++ b/src/sdl3/render.rs
@@ -49,6 +49,7 @@ use std::mem::{transmute, MaybeUninit};
 use std::ops::Deref;
 use std::ptr;
 use std::rc::Rc;
+use std::sync::Arc;
 use sys::blendmode::SDL_BlendMode;
 use sys::everything::SDL_PropertiesID;
 use sys::render::{SDL_GetTextureProperties, SDL_TextureAccess};
@@ -293,7 +294,7 @@ impl TryFrom<u32> for BlendMode {
 /// When the `RendererContext` is dropped, it destroys the `SDL_Renderer`
 pub struct RendererContext<T> {
     raw: *mut sys::render::SDL_Renderer,
-    _target: Rc<T>,
+    _target: Arc<T>,
 }
 
 impl<T> Drop for RendererContext<T> {
@@ -314,7 +315,7 @@ impl<T> RendererContext<T> {
         self.raw
     }
 
-    pub unsafe fn from_ll(raw: *mut sys::render::SDL_Renderer, target: Rc<T>) -> Self {
+    pub unsafe fn from_ll(raw: *mut sys::render::SDL_Renderer, target: Arc<T>) -> Self {
         RendererContext {
             raw,
             _target: target,

--- a/src/sdl3/surface.rs
+++ b/src/sdl3/surface.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::get_error;
 use crate::pixels;
@@ -38,12 +38,12 @@ impl<'a> Drop for SurfaceContext<'a> {
     }
 }
 
-/// Holds a `Rc<SurfaceContext>`.
+/// Holds an `Arc<SurfaceContext>`.
 ///
 /// Note: If a `Surface` goes out of scope but it cloned its context,
 /// then the `SDL_Surface` will not be free'd until there are no more references to the `SurfaceContext`.
 pub struct Surface<'a> {
-    context: Rc<SurfaceContext<'a>>,
+    context: Arc<SurfaceContext<'a>>,
 }
 
 /// An unsized Surface reference.
@@ -108,7 +108,7 @@ impl<'a> Surface<'a> {
             _marker: PhantomData,
         };
         Surface {
-            context: Rc::new(context),
+            context: Arc::new(context),
         }
     }
 
@@ -312,7 +312,7 @@ impl<'a> Surface<'a> {
         Canvas::from_surface(self)
     }
 
-    pub fn context(&self) -> Rc<SurfaceContext<'a>> {
+    pub fn context(&self) -> Arc<SurfaceContext<'a>> {
         self.context.clone()
     }
 }

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -12,7 +12,7 @@ use std::error::Error;
 use std::ffi::{CStr, CString, NulError};
 use std::ops::{Deref, DerefMut};
 use std::ptr::{null, null_mut};
-use std::rc::Rc;
+use std::sync::Arc;
 use std::{fmt, mem, ptr};
 use sys::properties::{
     SDL_CreateProperties, SDL_DestroyProperties, SDL_SetNumberProperty, SDL_SetStringProperty,
@@ -538,6 +538,9 @@ pub struct WindowContext {
     pub(crate) metal_view: sys::metal::SDL_MetalView,
 }
 
+unsafe impl Send for WindowContext {}
+unsafe impl Sync for WindowContext {}
+
 impl Drop for WindowContext {
     #[inline]
     #[doc(alias = "SDL_DestroyWindow")]
@@ -671,13 +674,13 @@ impl FlashOperation {
 /// then the `SDL_Window` will not be destroyed until there are no more references to the `WindowContext`.
 /// This may happen when a `TextureCreator<Window>` outlives the `Canvas<Window>`
 pub struct Window {
-    context: Rc<WindowContext>,
+    context: Arc<WindowContext>,
 }
 
 impl From<WindowContext> for Window {
     fn from(context: WindowContext) -> Window {
         Window {
-            context: Rc::new(context),
+            context: Arc::new(context),
         }
     }
 }
@@ -1495,7 +1498,7 @@ impl Window {
 
     #[inline]
     /// Create a new `Window` without taking ownership of the `WindowContext`
-    pub const unsafe fn from_ref(context: Rc<WindowContext>) -> Window {
+    pub const unsafe fn from_ref(context: Arc<WindowContext>) -> Window {
         Window { context }
     }
 
@@ -1509,7 +1512,7 @@ impl Window {
         self.into()
     }
 
-    pub fn context(&self) -> Rc<WindowContext> {
+    pub fn context(&self) -> Arc<WindowContext> {
         self.context.clone()
     }
 

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -538,9 +538,6 @@ pub struct WindowContext {
     pub(crate) metal_view: sys::metal::SDL_MetalView,
 }
 
-unsafe impl Send for WindowContext {}
-unsafe impl Sync for WindowContext {}
-
 impl Drop for WindowContext {
     #[inline]
     #[doc(alias = "SDL_DestroyWindow")]
@@ -674,7 +671,7 @@ impl FlashOperation {
 /// then the `SDL_Window` will not be destroyed until there are no more references to the `WindowContext`.
 /// This may happen when a `TextureCreator<Window>` outlives the `Canvas<Window>`
 pub struct Window {
-    context: Arc<WindowContext>,
+    context: Arc<WindowContext>, // Arc may not be needed, added because wgpu expects Window to be send/sync, though even with Arc this technically still isn't send/sync
 }
 
 impl From<WindowContext> for Window {

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -3,34 +3,46 @@ mod raw_window_handle_test {
     extern crate raw_window_handle;
     extern crate sdl3;
 
-    use self::raw_window_handle::{
-        HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
-    };
     use self::sdl3::video::Window;
+    use self::raw_window_handle::{HasWindowHandle, HasDisplayHandle, RawWindowHandle};
 
     #[cfg(target_os = "windows")]
     #[test]
     fn get_windows_handle() {
+        use raw_window_handle::RawDisplayHandle;
+
         let window = new_hidden_window();
-        match window.raw_window_handle() {
-            RawWindowHandle::Win32(windows_handle) => {
-                assert_ne!(windows_handle.hwnd, 0 as *mut libc::c_void);
-                println!("Successfully received Windows RawWindowHandle!");
-            }
-            x => assert!(
-                false,
+        let window_handle = match window.window_handle() {
+            Ok(v) => v,
+            Err(err) => panic!(
+                "Received error while getting window handle for Windows: {:?}",
+                err
+            ),
+        };
+        let raw_handle = match window_handle.as_raw() {
+            RawWindowHandle::Win32(v) => v,
+            x => panic!(
                 "Received wrong RawWindowHandle type for Windows: {:?}",
                 x
             ),
-        }
-        match window.raw_display_handle() {
-            RawDisplayHandle::Windows(_) => {}
-            x => assert!(
-                false,
+        };
+        assert_ne!(raw_handle.hwnd.get(), 0);
+        println!("Successfully received Windows RawWindowHandle!");
+        let display_handle = match window.display_handle() {
+            Ok(v) => v,
+            Err(err) => panic!(
+                "Received error while getting display handle for Windows: {:?}",
+                err
+            ),
+        };
+        match display_handle.as_raw() {
+            RawDisplayHandle::Windows(_) => {},
+            x => panic!(
                 "Received wrong RawDisplayHandle type for Windows: {:?}",
                 x
             ),
         }
+        println!("Successfully received Windows RawDisplayHandle!");
     }
 
     #[cfg(any(


### PR DESCRIPTION
NOTE: this has really big downsides, mostly:
- Users need to use `unsafe impl` for Send and Sync for a custom Window wrapper
- Many places are using Arc instead of Rc
- Only written and tested on windows so far

To be honest, this probably isn't worth it, but I though I'd give it a shot and see what I can do. I'm not sure what the effects of the unsafe impl are, but as far as I can tell, there's absolutely no other way to use sdl3 with newer versions of wgpu. Maybe it would be better to add the unsafe impls to specific fields of WindowContext, but it definitely has to be added somewhere. Also, I didn't update the non-windows code, but it should be really easy to copy the new windows code and tweak it in the case that this actually gets merged

This is more of an experiment if anything, and I'm curious what others think