### PR TITLE
update sdl3-sys to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.169"
 lazy_static = "1.4.0"
 
 [dependencies.sdl3-sys]
-version = "0.2.0+SDL3-preview-3.1.8"
+version = "0.4"
 
 [dependencies.c_vec]
 # allow both 1.* and 2.0 versions


### PR DESCRIPTION
This version of sdl3-sys supports the stable SDL 3.2.0 release