### PR TITLE
Derive `Clone` on Window

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -672,6 +672,7 @@ impl FlashOperation {
 /// Note: If a `Window` goes out of scope but it cloned its context,
 /// then the `SDL_Window` will not be destroyed until there are no more references to the `WindowContext`.
 /// This may happen when a `TextureCreator<Window>` outlives the `Canvas<Window>`
+#[derive(Clone)]
 pub struct Window {
     context: Arc<WindowContext>, // Arc may not be needed, added because wgpu expects Window to be send/sync, though even with Arc this technically still isn't send/sync
 }


### PR DESCRIPTION
Hey! Thank you for the work to get everything up and running with SDL3!

In porting a game from `sdl2` to `sdl3`, we ran into `Window` no longer being `Clone`. It looks like it just holds an `Arc` of the type that handles the actual logic, so it seems fine to add the derive!