### PR TITLE
macos objc2 version update, handle type verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.6.2"
 optional = true
 
 [target.'cfg(target_os = "macos")'.dependencies.objc2]
-version = "0.5.2"
+version = "0.6.0"
 optional = true
 
 [dev-dependencies]

--- a/src/sdl3/raw_window_handle.rs
+++ b/src/sdl3/raw_window_handle.rs
@@ -48,8 +48,11 @@ impl HasWindowHandle for Window {
                 sys::video::SDL_PROP_WINDOW_COCOA_WINDOW_POINTER,
                 std::ptr::null_mut(),
             );
-            let ns_view = msg_send![ns_window as *mut NSObject, contentView];
-            let handle = AppKitWindowHandle::new(NonNull::new_unchecked(ns_view));
+            let ns_view: *mut NSObject = msg_send![ns_window as *mut NSObject, contentView];
+            if ns_view.is_null() {
+                return Err(HandleError::Unavailable);
+            }
+            let handle = AppKitWindowHandle::new(NonNull::new_unchecked(ns_view.cast()));
             let raw_window_handle = RawWindowHandle::AppKit(handle);
 
             Ok(WindowHandle::borrow_raw(raw_window_handle))


### PR DESCRIPTION
#82 

- update objc2 crate version from 0.5.2 to 0.6.0
- hanlde type verification issue, and add a small exeption handling

only tested on my MacOS (M1 Apple Silicon, OS 15.3), so more test needs to verify.