### PR TITLE
Improve GPU memory management and error handling

### DIFF
--- a/examples/gpu-clear.rs
+++ b/examples/gpu-clear.rs
@@ -17,7 +17,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // by default, and we specify that our shaders will be SPIR-V ones (even through we
     // aren't using any shaders)
     // We'll also turn on debug mode to true, so we get debug stuff
-    let gpu = sdl3::gpu::Device::new(sdl3::gpu::ShaderFormat::SpirV, true).with_window(&window)?;
+    let gpu = sdl3::gpu::Device::new(sdl3::gpu::ShaderFormat::SpirV, true)?.with_window(&window)?;
 
     let mut event_pump = sdl_context.event_pump()?;
     println!(
@@ -40,12 +40,11 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         //
         // This is because a swapchain needs to be "allocated", and it can quickly run out
         // if we don't properly time the rendering process.
-        let mut command_buffer = gpu.acquire_command_buffer();
-        if let Ok(swapchain) = gpu.wait_and_acquire_swapchain_texture(&window, &mut command_buffer)
-        {
+        let mut command_buffer = gpu.acquire_command_buffer()?;
+        if let Ok(swapchain) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
             let color_targets = [
                 sdl3::gpu::ColorTargetInfo::default()
-                    .with_texture(swapchain) // Use swapchain texture
+                    .with_texture(&swapchain) // Use swapchain texture
                     .with_load_op(sdl3::gpu::LoadOp::Clear) // Clear when load
                     .with_store_op(sdl3::gpu::StoreOp::Store) // Store back
                     .with_clear_color(sdl3::pixels::Color::RGB(5, 3, 255)), //blue with small RG bias


### PR DESCRIPTION
This change wraps the inner points for the GPU Shader, Texture, GraphicsPipeline, Buffer, and TransferBuffer resources in Arcs so that manual memory management isn't necessary. These resources require the device to be released, so they also track a weak pointer back to the device, and their release is conditional on the device still existing.

The device itself now has its raw pointer wrapped in an Arc. Clone implementations are added to all of these to make working with them in a larger project easier.

The release functions were all removed, and the resources can simply be more idiomatically dropped now.

Additionally, the `wait_and_acquire_swapchain_texture` and `acquire_swapchain_texture` functions were moved from the Device into the CommandBuffer. This made more sense organizationally since neither functions use the device at all, and their first argument is the command buffer pointer.

Finally, missing error handling was added for many unsafe SDL function calls.