### PR TITLE
Get the image module working

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ lazy_static = "1.4.0"
 [dependencies.sdl3-sys]
 version = "0.4"
 
+[dependencies.sdl3-image-sys]
+version = "0.1"
+optional = true
+
 [dependencies.c_vec]
 # allow both 1.* and 2.0 versions
 version = ">= 1.0"
@@ -65,7 +69,7 @@ default = []
 unsafe_textures = []
 gfx = ["c_vec"]      #, "sdl3-sys/gfx"]
 #mixer = ["sdl3-sys/mixer"]
-#image = ["sdl3-sys/image"]
+image = ["dep:sdl3-image-sys"]
 #ttf = ["sdl3-sys/ttf"]
 # Use hidapi support in SDL. Only 2.0.12 and after
 hidapi = []

--- a/examples/image-demo.rs
+++ b/examples/image-demo.rs
@@ -1,7 +1,7 @@
 extern crate sdl3;
 
 use sdl3::event::Event;
-use sdl3::image::{InitFlag, LoadTexture};
+use sdl3::image::LoadTexture;
 use sdl3::keyboard::Keycode;
 use std::env;
 use std::path::Path;
@@ -9,18 +9,13 @@ use std::path::Path;
 pub fn run(png: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let sdl_context = sdl3::init()?;
     let video_subsystem = sdl_context.video()?;
-    let _image_context = sdl3::image::init(InitFlag::PNG | InitFlag::JPG)?;
     let window = video_subsystem
         .window("rust-sdl3 demo: Video", 800, 600)
         .position_centered()
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut canvas = window
-        .into_canvas()
-        .software()
-        .build()
-        .map_err(|e| e.to_string())?;
+    let mut canvas = window.into_canvas();
     let texture_creator = canvas.texture_creator();
     let texture = texture_creator.load_texture(png)?;
 

--- a/src/sdl3/image/mod.rs
+++ b/src/sdl3/image/mod.rs
@@ -20,64 +20,34 @@
 //! features = ["image"]
 //! ```
 
-use get_error;
-use iostream::IOStream;
-use render::{Texture, TextureCreator};
+use crate::iostream::IOStream;
+use crate::render::{Texture, TextureCreator};
+use crate::surface::Surface;
+use crate::version::Version;
+use crate::{get_error, Error};
+use sdl3_image_sys::image;
 use std::ffi::CString;
-use std::os::raw::{c_char, c_int};
+use std::os::raw::c_char;
 use std::path::Path;
-use surface::Surface;
 use sys;
-use sys::image;
-use version::Version;
-
-bitflags! {
-    /// InitFlags are passed to init() to control which subsystem
-    /// functionality to load.
-    pub struct InitFlag : u32 {
-        const JPG  = image::IMG_InitFlags_IMG_INIT_JPG as u32;
-        const PNG  = image::IMG_InitFlags_IMG_INIT_PNG as u32;
-        const TIF  = image::IMG_InitFlags_IMG_INIT_TIF as u32;
-        const WEBP = image::IMG_InitFlags_IMG_INIT_WEBP as u32;
-    }
-}
-
-// This is used for error message for init
-impl ::std::fmt::Display for InitFlag {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        if self.contains(InitFlag::JPG) {
-            f.write_str("INIT_JPG ")?;
-        }
-        if self.contains(InitFlag::PNG) {
-            f.write_str("INIT_PNG ")?;
-        }
-        if self.contains(InitFlag::TIF) {
-            f.write_str("INIT_TIF ")?;
-        }
-        if self.contains(InitFlag::WEBP) {
-            f.write_str("INIT_WEBP ")?;
-        }
-        Ok(())
-    }
-}
 
 /// Static method extensions for creating Surfaces
 pub trait LoadSurface: Sized {
     // Self is only returned here to type hint to the compiler.
     // The syntax for type hinting in this case is not yet defined.
-    // The intended return value is Result<~Surface, String>.
-    fn from_file<P: AsRef<Path>>(filename: P) -> Result<Self, String>;
-    fn from_xpm_array(xpm: *const *const i8) -> Result<Self, String>;
+    // The intended return value is Result<~Surface, Error>.
+    fn from_file<P: AsRef<Path>>(filename: P) -> Result<Self, Error>;
+    fn from_xpm_array(xpm: *const *const i8) -> Result<Self, Error>;
 }
 
 /// Method extensions to Surface for saving to disk
 pub trait SaveSurface {
-    fn save<P: AsRef<Path>>(&self, filename: P) -> Result<(), String>;
-    fn save_rw(&self, dst: &mut IOStream) -> Result<(), String>;
+    fn save<P: AsRef<Path>>(&self, filename: P) -> Result<(), Error>;
+    fn save_io(&self, dst: &mut IOStream) -> Result<(), Error>;
 }
 
 impl<'a> LoadSurface for Surface<'a> {
-    fn from_file<P: AsRef<Path>>(filename: P) -> Result<Surface<'a>, String> {
+    fn from_file<P: AsRef<Path>>(filename: P) -> Result<Surface<'a>, Error> {
         //! Loads an SDL Surface from a file
         unsafe {
             let c_filename = CString::new(filename.as_ref().to_str().unwrap()).unwrap();
@@ -90,7 +60,7 @@ impl<'a> LoadSurface for Surface<'a> {
         }
     }
 
-    fn from_xpm_array(xpm: *const *const i8) -> Result<Surface<'a>, String> {
+    fn from_xpm_array(xpm: *const *const i8) -> Result<Surface<'a>, Error> {
         //! Loads an SDL Surface from XPM data
         unsafe {
             let raw = image::IMG_ReadXPMFromArray(xpm as *mut *mut c_char);
@@ -104,28 +74,25 @@ impl<'a> LoadSurface for Surface<'a> {
 }
 
 impl<'a> SaveSurface for Surface<'a> {
-    fn save<P: AsRef<Path>>(&self, filename: P) -> Result<(), String> {
+    fn save<P: AsRef<Path>>(&self, filename: P) -> Result<(), Error> {
         //! Saves an SDL Surface to a file
         unsafe {
             let c_filename = CString::new(filename.as_ref().to_str().unwrap()).unwrap();
-            let status = image::IMG_SavePNG(self.raw(), c_filename.as_ptr() as *const _);
-            if status != 0 {
-                Err(get_error())
-            } else {
+            if image::IMG_SavePNG(self.raw(), c_filename.as_ptr() as *const _) {
                 Ok(())
+            } else {
+                Err(get_error())
             }
         }
     }
 
-    fn save_rw(&self, dst: &mut IOStream) -> Result<(), String> {
+    fn save_io(&self, dst: &mut IOStream) -> Result<(), Error> {
         //! Saves an SDL Surface to an IOStream
         unsafe {
-            let status = image::IMG_SavePNG_RW(self.raw(), dst.raw(), 0);
-
-            if status != 0 {
-                Err(get_error())
-            } else {
+            if image::IMG_SavePNG_IO(self.raw(), dst.raw(), false) {
                 Ok(())
+            } else {
+                Err(get_error())
             }
         }
     }
@@ -133,12 +100,12 @@ impl<'a> SaveSurface for Surface<'a> {
 
 /// Method extensions for creating Textures from a `TextureCreator`
 pub trait LoadTexture {
-    fn load_texture<P: AsRef<Path>>(&self, filename: P) -> Result<Texture, String>;
-    fn load_texture_bytes(&self, buf: &[u8]) -> Result<Texture, String>;
+    fn load_texture<P: AsRef<Path>>(&self, filename: P) -> Result<Texture, Error>;
+    fn load_texture_bytes(&self, buf: &[u8]) -> Result<Texture, Error>;
 }
 
 impl<T> LoadTexture for TextureCreator<T> {
-    fn load_texture<P: AsRef<Path>>(&self, filename: P) -> Result<Texture, String> {
+    fn load_texture<P: AsRef<Path>>(&self, filename: P) -> Result<Texture, Error> {
         //! Loads an SDL Texture from a file
         unsafe {
             let c_filename = CString::new(filename.as_ref().to_str().unwrap()).unwrap();
@@ -152,12 +119,14 @@ impl<T> LoadTexture for TextureCreator<T> {
     }
 
     #[doc(alias = "IMG_LoadTexture")]
-    fn load_texture_bytes(&self, buf: &[u8]) -> Result<Texture, String> {
+    fn load_texture_bytes(&self, buf: &[u8]) -> Result<Texture, Error> {
         //! Loads an SDL Texture from a buffer that the format must be something supported by sdl3_image (png, jpeg, ect, but NOT RGBA8888 bytes for instance)
         unsafe {
-            let buf =
-                sdl3_sys::SDL_RWFromMem(buf.as_ptr() as *mut libc::c_void, buf.len() as usize);
-            let raw = image::IMG_LoadTexture_RW(self.raw(), buf, 1); // close(free) buff after load
+            let buf = sdl3_sys::iostream::SDL_IOFromMem(
+                buf.as_ptr() as *mut libc::c_void,
+                buf.len() as usize,
+            );
+            let raw = image::IMG_LoadTexture_IO(self.raw(), buf, true); // close(free) buff after load
             if (raw as *mut ()).is_null() {
                 Err(get_error())
             } else {
@@ -167,46 +136,13 @@ impl<T> LoadTexture for TextureCreator<T> {
     }
 }
 
-/// Context manager for `sdl3_image` to manage quitting. Can't do much with it but
-/// keep it alive while you are using it.
-pub struct sdl3ImageContext;
-
-impl Drop for sdl3ImageContext {
-    fn drop(&mut self) {
-        unsafe {
-            image::IMG_Quit();
-        }
-    }
-}
-
-/// Initializes `sdl3_image` with `InitFlags`.
-/// If not every flag is set it returns an error
-pub fn init(flags: InitFlag) -> Result<sdl3ImageContext, String> {
-    let return_flags = unsafe {
-        let used = image::IMG_Init(flags.bits() as c_int);
-        InitFlag::from_bits_truncate(used as u32)
-    };
-    if !flags.intersects(return_flags) {
-        // According to docs, error message text is not always set
-        let mut error = get_error();
-        if error.is_empty() {
-            let un_init_flags = return_flags ^ flags;
-            error = format!("Could not init: {}", un_init_flags);
-            let _ = ::set_error(&error);
-        }
-        Err(error)
-    } else {
-        Ok(sdl3ImageContext)
-    }
-}
-
 /// Returns the version of the dynamically linked `SDL_image` library
 pub fn get_linked_version() -> Version {
-    unsafe { Version::from_ll(*image::IMG_Linked_Version()) }
+    unsafe { Version::from_ll(image::IMG_Version()) }
 }
 
 #[inline]
-fn to_surface_result<'a>(raw: *mut sys::SDL_Surface) -> Result<Surface<'a>, String> {
+fn to_surface_result<'a>(raw: *mut sys::surface::SDL_Surface) -> Result<Surface<'a>, Error> {
     if (raw as *mut ()).is_null() {
         Err(get_error())
     } else {
@@ -216,25 +152,25 @@ fn to_surface_result<'a>(raw: *mut sys::SDL_Surface) -> Result<Surface<'a>, Stri
 
 pub trait ImageIOStream {
     /// load as a surface. except TGA
-    fn load(&self) -> Result<Surface<'static>, String>;
+    fn load(&self) -> Result<Surface<'static>, Error>;
     /// load as a surface. This can load all supported image formats.
-    fn load_typed(&self, _type: &str) -> Result<Surface<'static>, String>;
+    fn load_typed(&self, _type: &str) -> Result<Surface<'static>, Error>;
 
-    fn load_cur(&self) -> Result<Surface<'static>, String>;
-    fn load_ico(&self) -> Result<Surface<'static>, String>;
-    fn load_bmp(&self) -> Result<Surface<'static>, String>;
-    fn load_pnm(&self) -> Result<Surface<'static>, String>;
-    fn load_xpm(&self) -> Result<Surface<'static>, String>;
-    fn load_xcf(&self) -> Result<Surface<'static>, String>;
-    fn load_pcx(&self) -> Result<Surface<'static>, String>;
-    fn load_gif(&self) -> Result<Surface<'static>, String>;
-    fn load_jpg(&self) -> Result<Surface<'static>, String>;
-    fn load_tif(&self) -> Result<Surface<'static>, String>;
-    fn load_png(&self) -> Result<Surface<'static>, String>;
-    fn load_tga(&self) -> Result<Surface<'static>, String>;
-    fn load_lbm(&self) -> Result<Surface<'static>, String>;
-    fn load_xv(&self) -> Result<Surface<'static>, String>;
-    fn load_webp(&self) -> Result<Surface<'static>, String>;
+    fn load_cur(&self) -> Result<Surface<'static>, Error>;
+    fn load_ico(&self) -> Result<Surface<'static>, Error>;
+    fn load_bmp(&self) -> Result<Surface<'static>, Error>;
+    fn load_pnm(&self) -> Result<Surface<'static>, Error>;
+    fn load_xpm(&self) -> Result<Surface<'static>, Error>;
+    fn load_xcf(&self) -> Result<Surface<'static>, Error>;
+    fn load_pcx(&self) -> Result<Surface<'static>, Error>;
+    fn load_gif(&self) -> Result<Surface<'static>, Error>;
+    fn load_jpg(&self) -> Result<Surface<'static>, Error>;
+    fn load_tif(&self) -> Result<Surface<'static>, Error>;
+    fn load_png(&self) -> Result<Surface<'static>, Error>;
+    fn load_tga(&self) -> Result<Surface<'static>, Error>;
+    fn load_lbm(&self) -> Result<Surface<'static>, Error>;
+    fn load_xv(&self) -> Result<Surface<'static>, Error>;
+    fn load_webp(&self) -> Result<Surface<'static>, Error>;
 
     fn is_cur(&self) -> bool;
     fn is_ico(&self) -> bool;
@@ -253,119 +189,119 @@ pub trait ImageIOStream {
 }
 
 impl<'a> ImageIOStream for IOStream<'a> {
-    fn load(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_Load_RW(self.raw(), 0) };
+    fn load(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_Load_IO(self.raw(), false) };
         to_surface_result(raw)
     }
-    fn load_typed(&self, _type: &str) -> Result<Surface<'static>, String> {
+    fn load_typed(&self, _type: &str) -> Result<Surface<'static>, Error> {
         let raw = unsafe {
             let c_type = CString::new(_type.as_bytes()).unwrap();
-            image::IMG_LoadTyped_RW(self.raw(), 0, c_type.as_ptr() as *const _)
+            image::IMG_LoadTyped_IO(self.raw(), false, c_type.as_ptr() as *const _)
         };
         to_surface_result(raw)
     }
 
-    fn load_cur(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadCUR_RW(self.raw()) };
+    fn load_cur(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadCUR_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_ico(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadICO_RW(self.raw()) };
+    fn load_ico(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadICO_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_bmp(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadBMP_RW(self.raw()) };
+    fn load_bmp(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadBMP_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_pnm(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadPNM_RW(self.raw()) };
+    fn load_pnm(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadPNM_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_xpm(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadXPM_RW(self.raw()) };
+    fn load_xpm(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadXPM_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_xcf(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadXCF_RW(self.raw()) };
+    fn load_xcf(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadXCF_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_pcx(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadPCX_RW(self.raw()) };
+    fn load_pcx(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadPCX_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_gif(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadGIF_RW(self.raw()) };
+    fn load_gif(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadGIF_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_jpg(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadJPG_RW(self.raw()) };
+    fn load_jpg(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadJPG_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_tif(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadTIF_RW(self.raw()) };
+    fn load_tif(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadTIF_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_png(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadPNG_RW(self.raw()) };
+    fn load_png(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadPNG_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_tga(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadTGA_RW(self.raw()) };
+    fn load_tga(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadTGA_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_lbm(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadLBM_RW(self.raw()) };
+    fn load_lbm(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadLBM_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_xv(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadXV_RW(self.raw()) };
+    fn load_xv(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadXV_IO(self.raw()) };
         to_surface_result(raw)
     }
-    fn load_webp(&self) -> Result<Surface<'static>, String> {
-        let raw = unsafe { image::IMG_LoadWEBP_RW(self.raw()) };
+    fn load_webp(&self) -> Result<Surface<'static>, Error> {
+        let raw = unsafe { image::IMG_LoadWEBP_IO(self.raw()) };
         to_surface_result(raw)
     }
 
     fn is_cur(&self) -> bool {
-        unsafe { image::IMG_isCUR(self.raw()) == 1 }
+        unsafe { image::IMG_isCUR(self.raw()) }
     }
     fn is_ico(&self) -> bool {
-        unsafe { image::IMG_isICO(self.raw()) == 1 }
+        unsafe { image::IMG_isICO(self.raw()) }
     }
     fn is_bmp(&self) -> bool {
-        unsafe { image::IMG_isBMP(self.raw()) == 1 }
+        unsafe { image::IMG_isBMP(self.raw()) }
     }
     fn is_pnm(&self) -> bool {
-        unsafe { image::IMG_isPNM(self.raw()) == 1 }
+        unsafe { image::IMG_isPNM(self.raw()) }
     }
     fn is_xpm(&self) -> bool {
-        unsafe { image::IMG_isXPM(self.raw()) == 1 }
+        unsafe { image::IMG_isXPM(self.raw()) }
     }
     fn is_xcf(&self) -> bool {
-        unsafe { image::IMG_isXCF(self.raw()) == 1 }
+        unsafe { image::IMG_isXCF(self.raw()) }
     }
     fn is_pcx(&self) -> bool {
-        unsafe { image::IMG_isPCX(self.raw()) == 1 }
+        unsafe { image::IMG_isPCX(self.raw()) }
     }
     fn is_gif(&self) -> bool {
-        unsafe { image::IMG_isGIF(self.raw()) == 1 }
+        unsafe { image::IMG_isGIF(self.raw()) }
     }
     fn is_jpg(&self) -> bool {
-        unsafe { image::IMG_isJPG(self.raw()) == 1 }
+        unsafe { image::IMG_isJPG(self.raw()) }
     }
     fn is_tif(&self) -> bool {
-        unsafe { image::IMG_isTIF(self.raw()) == 1 }
+        unsafe { image::IMG_isTIF(self.raw()) }
     }
     fn is_png(&self) -> bool {
-        unsafe { image::IMG_isPNG(self.raw()) == 1 }
+        unsafe { image::IMG_isPNG(self.raw()) }
     }
     fn is_lbm(&self) -> bool {
-        unsafe { image::IMG_isLBM(self.raw()) == 1 }
+        unsafe { image::IMG_isLBM(self.raw()) }
     }
     fn is_xv(&self) -> bool {
-        unsafe { image::IMG_isXV(self.raw()) == 1 }
+        unsafe { image::IMG_isXV(self.raw()) }
     }
     fn is_webp(&self) -> bool {
-        unsafe { image::IMG_isWEBP(self.raw()) == 1 }
+        unsafe { image::IMG_isWEBP(self.raw()) }
     }
 }

--- a/src/sdl3/version.rs
+++ b/src/sdl3/version.rs
@@ -22,9 +22,9 @@ impl Version {
     pub fn from_ll(v: i32) -> Version {
         // pub const SDL_VERSION: i32 = _; // 3_001_003i32
         Version {
-            major: (v >> 16) as u8,
-            minor: ((v >> 8) & 0xFF) as u8,
-            patch: (v & 0xFF) as u8,
+            major: (v / 1_000_000) as u8,
+            minor: (v % 1_000_000 / 1_000) as u8,
+            patch: (v % 1_000) as u8,
         }
     }
 }


### PR DESCRIPTION
Kind of quick and dirty but I verified that it works. Use the `build-from-source` feature of `sdl3-image-sys` if it can't find SDL_image

Also contains a fix for `Version::from_ll`. The versions returned by SDL and its satellites are in decimal format with millions and thousands for major and minor version respectively