### PR TITLE
clipping rect disambiguate

### DIFF
--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1,0 +1,82 @@
+use sdl3::{rect::Rect, render::ClippingRect};
+
+extern crate sdl3;
+
+#[test]
+fn clipping_rect_intersection() {
+    // a zero area clipping rect intersecting with anything else gives zero.
+    assert_eq!(
+        ClippingRect::Zero.intersection(ClippingRect::Zero),
+        ClippingRect::Zero
+    );
+    assert_eq!(
+        ClippingRect::Zero.intersection(ClippingRect::None),
+        ClippingRect::Zero
+    );
+    assert_eq!(
+        ClippingRect::Zero.intersection(ClippingRect::Some(Rect::new(0, 0, 1, 1))),
+        ClippingRect::Zero
+    );
+
+    // none gives whatever the arg was
+    assert_eq!(
+        ClippingRect::None.intersection(ClippingRect::Zero),
+        ClippingRect::Zero
+    );
+    assert_eq!(
+        ClippingRect::None.intersection(ClippingRect::None),
+        ClippingRect::None
+    );
+    assert_eq!(
+        ClippingRect::None.intersection(ClippingRect::Some(Rect::new(0, 0, 1, 1))),
+        ClippingRect::Some(Rect::new(0, 0, 1, 1))
+    );
+
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 1, 1)).intersection(ClippingRect::Zero),
+        ClippingRect::Zero
+    );
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 1, 1)).intersection(ClippingRect::None),
+        ClippingRect::Some(Rect::new(0, 0, 1, 1))
+    );
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 10, 10))
+            .intersection(ClippingRect::Some(Rect::new(20, 20, 1, 1))),
+        ClippingRect::Zero
+    );
+
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 10, 10))
+            .intersection(ClippingRect::Some(Rect::new(5, 5, 10, 10))),
+        ClippingRect::Some(Rect::new(5, 5, 5, 5))
+    );
+}
+
+#[test]
+fn clipping_rect_intersect_rect() {
+    assert_eq!(ClippingRect::Zero.intersect_rect(None), ClippingRect::Zero);
+    assert_eq!(
+        ClippingRect::Zero.intersect_rect(Rect::new(0, 0, 1, 1)),
+        ClippingRect::Zero
+    );
+
+    assert_eq!(ClippingRect::None.intersect_rect(None), ClippingRect::Zero);
+    assert_eq!(
+        ClippingRect::None.intersect_rect(Rect::new(0, 0, 1, 1)),
+        ClippingRect::Some(Rect::new(0, 0, 1, 1))
+    );
+
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 1, 1)).intersect_rect(None),
+        ClippingRect::Zero
+    );
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 10, 10)).intersect_rect(Rect::new(5, 5, 10, 10)),
+        ClippingRect::Some(Rect::new(5, 5, 5, 5))
+    );
+    assert_eq!(
+        ClippingRect::Some(Rect::new(0, 0, 10, 10)).intersect_rect(Rect::new(20, 20, 1, 1)),
+        ClippingRect::Zero
+    );
+}


### PR DESCRIPTION
PR got [auto deleted](https://github.com/vhspace/sdl3-rs/pull/97) once the fork was [detached](https://github.com/vhspace/sdl3-rs/issues/94#issuecomment-2645859598). Recreating this PR here.

----

from: https://github.com/Rust-SDL2/rust-sdl2/pull/1450. see explanation there. The same reasoning applies for [sdl3](https://github.com/libsdl-org/SDL/blob/864bb65ce9dc35c08fb03ff9570b8f04dbb76c33/src/render/SDL_render.c#L3073).

this is a breaking change for querying the clipping rect. different type is returned now