### PR TITLE
make Sdl and subsystem structs zero sized

### DIFF
--- a/src/sdl3/sdl.rs
+++ b/src/sdl3/sdl.rs
@@ -193,6 +193,7 @@ impl Drop for SdlDrop {
             unsafe {
                 sys::init::SDL_Quit();
             }
+            IS_MAIN_THREAD_DECLARED.store(false, Ordering::SeqCst);
         }
     }
 }


### PR DESCRIPTION
These structs kept no state, only constants.

Also prevents `SDL_COUNT` from being modified from other threads than the main thread by keeping one count per subsystem *type*, not instance.

