### PR TITLE
Add push_fragment_uniform_data to CommandBuffer

### DIFF
--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -12,8 +12,8 @@ use sys::gpu::{
     SDL_BindGPUVertexBuffers, SDL_DrawGPUIndexedPrimitives, SDL_GPUBufferBinding,
     SDL_GPUColorTargetInfo, SDL_GPUCommandBuffer, SDL_GPUComputePass, SDL_GPUCopyPass,
     SDL_GPUDepthStencilTargetInfo, SDL_GPUIndexElementSize, SDL_GPULoadOp, SDL_GPURenderPass,
-    SDL_GPUStoreOp, SDL_GPUTextureSamplerBinding, SDL_PushGPUVertexUniformData,
-    SDL_PushGPUFragmentUniformData, SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture,
+    SDL_GPUStoreOp, SDL_GPUTextureSamplerBinding, SDL_PushGPUFragmentUniformData,
+    SDL_PushGPUVertexUniformData, SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture,
     SDL_WaitAndAcquireGPUSwapchainTexture,
 };
 
@@ -43,7 +43,7 @@ impl CommandBuffer {
     }
 
     #[doc(alias = "SDL_PushGPUFragmentUniformData")]
-    pub fn push_fragment_uniform_data<T : Sized>(&self, slot_index: u32, data: &T) {
+    pub fn push_fragment_uniform_data<T: Sized>(&self, slot_index: u32, data: &T) {
         unsafe {
             SDL_PushGPUFragmentUniformData(
                 self.raw(),

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -13,7 +13,8 @@ use sys::gpu::{
     SDL_GPUColorTargetInfo, SDL_GPUCommandBuffer, SDL_GPUComputePass, SDL_GPUCopyPass,
     SDL_GPUDepthStencilTargetInfo, SDL_GPUIndexElementSize, SDL_GPULoadOp, SDL_GPURenderPass,
     SDL_GPUStoreOp, SDL_GPUTextureSamplerBinding, SDL_PushGPUVertexUniformData,
-    SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture, SDL_WaitAndAcquireGPUSwapchainTexture,
+    SDL_PushGPUFragmentUniformData, SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture,
+    SDL_WaitAndAcquireGPUSwapchainTexture,
 };
 
 pub struct CommandBuffer {
@@ -33,6 +34,18 @@ impl CommandBuffer {
     pub fn push_vertex_uniform_data<T: Sized>(&self, slot_index: u32, data: &T) {
         unsafe {
             SDL_PushGPUVertexUniformData(
+                self.raw(),
+                slot_index,
+                (data as *const T) as *const std::ffi::c_void,
+                size_of::<T>() as u32,
+            )
+        }
+    }
+
+    #[doc(alias = "SDL_PushGPUFragmentUniformData")]
+    pub fn push_fragment_uniform_data<T : Sized>(&self, slot_index: u32, data: &T) {
+        unsafe {
+            SDL_PushGPUFragmentUniformData(
                 self.raw(),
                 slot_index,
                 (data as *const T) as *const std::ffi::c_void,


### PR DESCRIPTION
I tried to follow along the [Depth Sampler Example for SDL3's GPU API](https://github.com/TheSpydog/SDL_gpu_examples/blob/main/Examples/DepthSampler.c) but noticed this library was missing the `push_fragment_uniform_data` method on the `CommandBuffer`.