### PR TITLE
Added conversion between event and render coordinates.

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -2578,7 +2578,7 @@ impl Event {
     // Returns `None` if the event cannot be converted to its raw form (should not happen).
     pub fn get_converted_coords<T: crate::render::RenderTarget>(
         &self,
-        canvas: crate::render::Canvas<T>,
+        canvas: &crate::render::Canvas<T>,
     ) -> Option<Event> {
         let mut raw = self.to_ll()?;
         unsafe {
@@ -2590,7 +2590,7 @@ impl Event {
     // Returns `true` on success and false if the event cannot be converted to its raw form (should not happen)
     pub fn convert_coords<T: crate::render::RenderTarget>(
         &mut self,
-        canvas: crate::render::Canvas<T>,
+        canvas: &crate::render::Canvas<T>,
     ) -> bool {
         if let Some(mut raw) = self.to_ll() {
             unsafe {

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -2574,6 +2574,24 @@ impl Event {
     pub fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
     }
+
+    // Returns `None` if the event cannot be converted to its raw form (should not happen).
+    pub fn get_converted_coords<T: crate::render::RenderTarget>(&self, canvas: crate::render::Canvas<T>) -> Option<Event> {
+        let mut raw = self.to_ll()?;
+        unsafe { sys::render::SDL_ConvertEventToRenderCoordinates(canvas.raw(), &mut raw); }
+        Some(Self::from_ll(raw))
+    }
+
+    // Returns `true` on succes and false if the event cannot be converted to its raw form (should not happen)
+    pub fn convert_coords<T: crate::render::RenderTarget>(&mut self, canvas: crate::render::Canvas<T>) -> bool {
+        if let Some(mut raw) = self.to_ll() {
+            unsafe { sys::render::SDL_ConvertEventToRenderCoordinates(canvas.raw(), &mut raw); }
+            *self = Self::from_ll(raw);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 unsafe fn poll_event() -> Option<Event> {

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -2576,16 +2576,26 @@ impl Event {
     }
 
     // Returns `None` if the event cannot be converted to its raw form (should not happen).
-    pub fn get_converted_coords<T: crate::render::RenderTarget>(&self, canvas: crate::render::Canvas<T>) -> Option<Event> {
+    pub fn get_converted_coords<T: crate::render::RenderTarget>(
+        &self,
+        canvas: crate::render::Canvas<T>,
+    ) -> Option<Event> {
         let mut raw = self.to_ll()?;
-        unsafe { sys::render::SDL_ConvertEventToRenderCoordinates(canvas.raw(), &mut raw); }
+        unsafe {
+            sys::render::SDL_ConvertEventToRenderCoordinates(canvas.raw(), &mut raw);
+        }
         Some(Self::from_ll(raw))
     }
 
-    // Returns `true` on succes and false if the event cannot be converted to its raw form (should not happen)
-    pub fn convert_coords<T: crate::render::RenderTarget>(&mut self, canvas: crate::render::Canvas<T>) -> bool {
+    // Returns `true` on success and false if the event cannot be converted to its raw form (should not happen)
+    pub fn convert_coords<T: crate::render::RenderTarget>(
+        &mut self,
+        canvas: crate::render::Canvas<T>,
+    ) -> bool {
         if let Some(mut raw) = self.to_ll() {
-            unsafe { sys::render::SDL_ConvertEventToRenderCoordinates(canvas.raw(), &mut raw); }
+            unsafe {
+                sys::render::SDL_ConvertEventToRenderCoordinates(canvas.raw(), &mut raw);
+            }
             *self = Self::from_ll(raw);
             true
         } else {


### PR DESCRIPTION
`Canvas::set_logical_size` no longer converts window events in SDL3 and `SDL_ConvertEventToRenderCoordinates` has to be used instead. For now I have one method that copies the event and one that modifies it.
One of them probably makes more sense and the other could be removed.