### PR TITLE
added Properties::const_from_ll for Display type

### DIFF
--- a/src/sdl3/properties.rs
+++ b/src/sdl3/properties.rs
@@ -22,7 +22,7 @@ pub enum PropertiesError {
 #[derive(Debug, Clone)]
 pub struct Properties {
     internal: sys::properties::SDL_PropertiesID,
-    global: bool,
+    constant: bool,
 }
 
 macro_rules! cstring {
@@ -73,7 +73,7 @@ impl Properties {
         } else {
             Ok(Self {
                 internal,
-                global: false,
+                constant: false,
             })
         }
     }
@@ -81,7 +81,14 @@ impl Properties {
     pub fn from_ll(props: SDL_PropertiesID) -> Self {
         Self {
             internal: props,
-            global: false,
+            constant: false,
+        }
+    }
+
+    pub fn const_from_ll(props: SDL_PropertiesID) -> Self {
+        Self {
+            internal: props,
+            constant: true,
         }
     }
 
@@ -93,7 +100,7 @@ impl Properties {
         } else {
             Ok(Self {
                 internal,
-                global: true,
+                constant: true,
             })
         }
     }
@@ -394,7 +401,7 @@ impl<T> Getter<*mut T> for Properties {
 
 impl Drop for Properties {
     fn drop(&mut self) {
-        if !self.global {
+        if !self.constant {
             unsafe {
                 sys::properties::SDL_DestroyProperties(self.internal);
             }

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -727,7 +727,7 @@ impl Display {
         if internal == 0 {
             Err(PropertiesError::SdlError(get_error()))
         } else {
-            Ok(Properties::from_ll(internal))
+            Ok(Properties::const_from_ll(internal))
         }
     }
 


### PR DESCRIPTION
When testing the new display type, specifically `Display::get_properties` I noticed that the properties where being deleted.
Now with the option to create a Properties type as constant (instead of just global being constant), the Display properties no longer get deleted. Maybe the function should have a different name.