### PR TITLE
keep `AudioSubsystem` alive while `AudioDevice`s or `AudioStream`a are alive

### DIFF
--- a/src/sdl3/sdl.rs
+++ b/src/sdl3/sdl.rs
@@ -256,6 +256,20 @@ macro_rules! subsystem {
                     marker: PhantomData,
                 })
             }
+
+            #[doc = concat!("Create a [`", stringify!($name), "`] out of thin air.")]
+            #[doc = ""]
+            #[doc = concat!("This is probably not what you are looking for. To initialize the subsystem use [`", stringify!($name), "::new`].")]
+            #[doc = ""]
+            #[doc = "# Safety"]
+            #[doc = ""]
+            #[doc = concat!("For each time this is called, previously a [`", stringify!($name), "`] must have been passed to [`mem::forget`].")]
+            #[allow(dead_code, reason = "not all subsystems need this right now")]
+            pub(crate) unsafe fn new_unchecked() -> Self {
+                Self {
+                    marker: PhantomData,
+                }
+            }
         }
 
         impl Clone for $name {


### PR DESCRIPTION
breaking change because some functions allowed creating streams or devices without requiring an `AudioSubsystem`

fixes #79