### PR TITLE
Reintroduced missing `Texture` and `Texture<'r>` functions.

### DIFF
--- a/src/sdl3/render.rs
+++ b/src/sdl3/render.rs
@@ -2394,6 +2394,42 @@ impl InternalTexture {
 
 #[cfg(not(feature = "unsafe_textures"))]
 impl Texture<'_> {
+    /// Gets the texture's internal properties.
+    #[inline]
+    pub fn query(&self) -> TextureQuery {
+        let internal = InternalTexture { raw: self.raw };
+        TextureQuery {
+            format: internal.get_format(),
+            access: internal.get_access(),
+            width: internal.get_width(),
+            height: internal.get_height(),
+        }
+    }
+
+    /// Get the format of the texture.
+    #[inline]
+    pub fn format(&self) -> PixelFormat {
+        InternalTexture { raw: self.raw }.get_format()
+    }
+
+    /// Get the access of the texture.
+    #[inline]
+    pub fn access(&self) -> TextureAccess {
+        InternalTexture { raw: self.raw }.get_access()
+    }
+
+    /// Get the width of the texture.
+    #[inline]
+    pub fn width(&self) -> u32 {
+        InternalTexture { raw: self.raw }.get_width()
+    }
+
+    /// Get the height of the texture.
+    #[inline]
+    pub fn height(&self) -> u32 {
+        InternalTexture { raw: self.raw }.get_height()
+    }
+
     /// Sets an additional color value multiplied into render copy operations.
     #[inline]
     pub fn set_color_mod(&mut self, red: u8, green: u8, blue: u8) {
@@ -2593,6 +2629,18 @@ impl Texture<'_> {
 
 #[cfg(feature = "unsafe_textures")]
 impl Texture {
+    /// Gets the texture's internal properties.
+    #[inline]
+    pub fn query(&self) -> TextureQuery {
+        let internal = InternalTexture { raw: self.raw };
+        TextureQuery {
+            format: internal.get_format(),
+            access: internal.get_access(),
+            width: internal.get_width(),
+            height: internal.get_height(),
+        }
+    }
+
     /// Get the format of the texture.
     #[inline]
     pub fn format(&self) -> PixelFormat {


### PR DESCRIPTION
In comparison to SDL2 for Rust, you could query for `TextureQuery` to get properties for the `Texture`. However, currently these are only accessible to `TextureInternal` and not publicly accessible.  One exception is that the unsafe `Texture` has the ability to obtain the individual properties of a `TextureQuery` but this is missing from the safe version. I've noticed `TextureQuery` has gone unused and added the ability for both the unsafe and safe version to return the query, piggybacking off of the already existing internal implementations. 

Additionally I added the missing functions that are present on unsafe textures to the safe variant, which are the same as the query but not wrapped up in the `TextureQuery` struct.

For reference to the SDL2 version where the query function exists.
Safe: [SDL2 Texture<'r>::query](https://github.com/Rust-SDL2/rust-sdl2/blob/34867707c9b255598fcbf20e9cdfb01085e41f00/src/sdl2/render.rs#L2516)
Unsafe: [SDL2 Texture::query](https://github.com/Rust-SDL2/rust-sdl2/blob/34867707c9b255598fcbf20e9cdfb01085e41f00/src/sdl2/render.rs#L2713)