### PR TITLE
Fix UB in render::create_renderer

### DIFF
--- a/src/sdl3/render.rs
+++ b/src/sdl3/render.rs
@@ -788,14 +788,14 @@ pub struct TextureCreator<T> {
 #[doc(alias = "SDL_CreateRenderer")]
 pub fn create_renderer(
     window: Window,
-    renderer_name: Option<&str>,
+    renderer_name: Option<&CStr>,
 ) -> Result<WindowCanvas, IntegerOrSdlError> {
     use crate::common::IntegerOrSdlError::*;
     let raw = unsafe {
         sys::render::SDL_CreateRenderer(
             window.raw(),
             if let Some(renderer_name) = renderer_name {
-                renderer_name.as_ptr() as *const _
+                renderer_name.as_ptr()
             } else {
                 std::ptr::null()
             },

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1,6 +1,5 @@
-use sdl3::{rect::Rect, render::ClippingRect, render::create_renderer};
-
 extern crate sdl3;
+use sdl3::{rect::Rect, render::create_renderer, render::ClippingRect};
 
 #[test]
 fn clipping_rect_intersection() {
@@ -84,14 +83,16 @@ fn clipping_rect_intersect_rect() {
 #[test]
 fn creating_a_named_renderer() {
     // hidden window
-    let window = sdl3::init().unwrap().video().unwrap()
+    let window = sdl3::init()
+        .unwrap()
+        .video()
+        .unwrap()
         .window("Hello, World!", 800, 600)
         .hidden()
         .metal_view()
         .build()
         .unwrap();
-    
+
     // the software renderer should always be available
     create_renderer(window, Some(c"software")).unwrap();
 }
-

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1,4 +1,4 @@
-use sdl3::{rect::Rect, render::ClippingRect};
+use sdl3::{rect::Rect, render::ClippingRect, render::create_renderer};
 
 extern crate sdl3;
 
@@ -80,3 +80,18 @@ fn clipping_rect_intersect_rect() {
         ClippingRect::Zero
     );
 }
+
+#[test]
+fn creating_a_named_renderer() {
+    // hidden window
+    let window = sdl3::init().unwrap().video().unwrap()
+        .window("Hello, World!", 800, 600)
+        .hidden()
+        .metal_view()
+        .build()
+        .unwrap();
+    
+    // the software renderer should always be available
+    create_renderer(window, Some(c"software")).unwrap();
+}
+


### PR DESCRIPTION
Hello, thank you for the hard work on this crate! So I was playing around with it and got a strange error that I tracked to the current implementation of the following function, which causes UB by converting a rust `&str` to a raw pointer (line 798) and passing it to a C API that expects a null-terminated byte string (a C-style string). Rust strings slices are not null-terminated, so I changed the function to accept a `CStr` instead. This of course is a breaking change, I think is easier and cleaner to do it this way, this is my first Rust contribution ever, so let me know if it is acceptable. I also added a test for it.

https://github.com/vhspace/sdl3-rs/blob/45ab2d24729cf7180e96a31cf346dbcee3a99698/src/sdl3/render.rs#L787-L803

Edit: I was looking at the rest of the code, and every situation where this happen it is preferred to allocate a `CString` in the functions, should I do it that way? Also there are some parts of the code where this same issue is happening, like in here:
https://github.com/vhspace/sdl3-rs/blob/45ab2d24729cf7180e96a31cf346dbcee3a99698/src/sdl3/video.rs#L881

I will add a fix for that too when I have time, later today probably.