### PR TITLE
Fix bug in clipboard text

### DIFF
--- a/src/sdl3/clipboard.rs
+++ b/src/sdl3/clipboard.rs
@@ -36,7 +36,7 @@ impl ClipboardUtil {
             let text = CString::new(text).unwrap();
             let result = sys::clipboard::SDL_SetClipboardText(text.as_ptr() as *const c_char);
 
-            if result {
+            if !result {
                 Err(get_error())
             } else {
                 Ok(())

--- a/tests/clipboard.rs
+++ b/tests/clipboard.rs
@@ -1,0 +1,15 @@
+extern crate sdl3;
+
+#[test]
+fn test_clipboard() {
+    let sdl_context = sdl3::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    let clipboard = video_subsystem.clipboard();
+    let text = "Hello World!";
+
+    // set some text
+    assert!(clipboard.set_clipboard_text(text).is_ok());
+    assert!(clipboard.has_clipboard_text());
+    // get it back
+    assert_eq!(clipboard.clipboard_text(), Ok(text.to_string()));
+}


### PR DESCRIPTION
` sys::clipboard::SDL_SetClipboardText` returns `true` on success, but condition was inverted.