### PR TITLE
AudioStream locking support with Callback API

### DIFF
--- a/examples/audio-capture-and-replay.rs
+++ b/examples/audio-capture-and-replay.rs
@@ -92,16 +92,12 @@ fn calculate_max_volume(recorded_vec: &[i16]) -> f32 {
 }
 
 struct SoundPlayback {
-    data: Vec<i16>,
-    pos: usize,
+    data: Vec<i16>
 }
 
 impl AudioCallback<i16> for SoundPlayback {
-    fn callback(&mut self, out: &mut [i16]) {
-        for dst in out.iter_mut() {
-            *dst = *self.data.get(self.pos).unwrap_or(&0);
-            self.pos += 1;
-        }
+    fn callback(&mut self, stream: &mut AudioStreamInner, requested: i32) {
+        stream.put_data_i16(&self.data).unwrap();
     }
 }
 
@@ -115,8 +111,7 @@ fn replay_recorded_vec(
     let playback_device = audio_subsystem.open_playback_stream(
         desired_spec,
         SoundPlayback {
-            data: recorded_vec,
-            pos: 0,
+            data: recorded_vec
         },
     )?;
 

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,17 +1,17 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStreamInner};
+use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStream};
 use std::time::Duration;
 
 struct SquareWave {
     phase_inc: f32,
     phase: f32,
     volume: f32,
-    buffer: Vec<f32>
+    buffer: Vec<f32>,
 }
 
 impl AudioCallback<f32> for SquareWave {
-    fn callback(&mut self, stream: &mut AudioStreamInner, requested: i32) {
+    fn callback(&mut self, stream: &mut AudioStream, requested: i32) {
         self.buffer.resize(requested as usize, 0.0);
 
         // Generate a square wave
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             phase_inc: 440.0 / desired_spec.freq.unwrap() as f32,
             phase: 0.0,
             volume: 0.25,
-            buffer: Vec::new()
+            buffer: Vec::new(),
         },
     )?;
 

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpec};
+use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec};
 use std::time::Duration;
 
 struct SquareWave {
@@ -28,9 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let audio_subsystem = sdl_context.audio()?;
 
     let desired_spec = AudioSpec {
-        freq: Some(44_100),
+        freq: Some(48000),
         channels: Some(1), // mono
-        format: None,
+        format: Some(AudioFormat::f32_sys()),
     };
 
     let device = audio_subsystem.open_playback_stream(

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,18 +1,21 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec};
+use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStreamInner};
 use std::time::Duration;
 
 struct SquareWave {
     phase_inc: f32,
     phase: f32,
     volume: f32,
+    buffer: Vec<f32>
 }
 
 impl AudioCallback<f32> for SquareWave {
-    fn callback(&mut self, out: &mut [f32]) {
+    fn callback(&mut self, stream: &mut AudioStreamInner, requested: i32) {
+        self.buffer.resize(requested as usize, 0.0);
+
         // Generate a square wave
-        for x in out.iter_mut() {
+        for x in self.buffer.iter_mut() {
             *x = if self.phase <= 0.5 {
                 self.volume
             } else {
@@ -20,6 +23,8 @@ impl AudioCallback<f32> for SquareWave {
             };
             self.phase = (self.phase + self.phase_inc) % 1.0;
         }
+
+        stream.put_data_f32(&self.buffer).unwrap();
     }
 }
 
@@ -39,6 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             phase_inc: 440.0 / desired_spec.freq.unwrap() as f32,
             phase: 0.0,
             volume: 0.25,
+            buffer: Vec::new()
         },
     )?;
 

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpec, AudioSpecWAV};
+use sdl3::audio::{AudioCallback, AudioSpec, AudioSpecWAV, AudioStreamInner};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -14,8 +14,10 @@ struct Sound {
     pos: usize,
 }
 
+// FIXME: Adapt to new playback api.
+#[cfg(feature = "")]
 impl AudioCallback<u8> for Sound {
-    fn callback(&mut self, out: &mut [u8]) {
+    fn callback(&mut self, out: &[u8]) {
         for dst in out.iter_mut() {
             // With channel type u8 the "silence" value is 128 (middle of the 0-2^8 range) so we need
             // to both fill in the silence and scale the wav data accordingly. Filling the silence

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -1,6 +1,6 @@
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioSpec, AudioSpecWAV, AudioStreamInner};
+use sdl3::audio::{AudioCallback, AudioSpec, AudioSpecWAV, AudioStream};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,15 +1,15 @@
 extern crate rand;
 extern crate sdl3;
 
-use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStreamInner};
+use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStream};
 use std::time::Duration;
 
 struct MyCallback {
     volume: f32,
-    buffer: Vec<f32>
+    buffer: Vec<f32>,
 }
 impl AudioCallback<f32> for MyCallback {
-    fn callback(&mut self, stream: &mut AudioStreamInner, requested: i32) {
+    fn callback(&mut self, stream: &mut AudioStream, requested: i32) {
         use self::rand::{thread_rng, Rng};
         let mut rng = thread_rng();
 
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &desired_spec,
         MyCallback {
             volume: 0.0,
-            buffer: Vec::new()
+            buffer: Vec::new(),
         },
     )?;
 


### PR DESCRIPTION
This PR, not only adds support for locking an AudioStream in callback mode, but also modifies the existing callback API—both of recording and playback—to closely resemble the [C API](https://wiki.libsdl.org/SDL3/SDL_AudioStreamCallback) of SDL 3.

Earlier examples looked akin to:
```rs
use sdl3::audio::{AudioCallback, AudioSpec};
use std::time::Duration;

struct SquareWave {
    phase_inc: f32,
    phase: f32,
    volume: f32,
}

impl AudioCallback<f32> for SquareWave {
    fn callback(&mut self, out: &mut [f32]) {
        // Generate a square wave
        for x in out.iter_mut() {
            *x = if self.phase <= 0.5 {
                self.volume
            } else {
                -self.volume
            };
            self.phase = (self.phase + self.phase_inc) % 1.0;
        }
    }
}

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let sdl_context = sdl3::init()?;
    let audio_subsystem = sdl_context.audio()?;

    let desired_spec = AudioSpec {
        freq: Some(44_100),
        channels: Some(1), // mono
        format: None,
    };

    let device = audio_subsystem.open_playback_stream(
        &desired_spec,
        SquareWave {
            phase_inc: 440.0 / desired_spec.freq.unwrap() as f32,
            phase: 0.0,
            volume: 0.25,
        },
    )?;

    // Start playback
    device.resume()?;

    // Play for 2 seconds
    std::thread::sleep(Duration::from_millis(2_000));

    // Device is automatically closed when dropped

    Ok(())
}
```
Now, they look like:
```rs
use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStreamInner};
use std::time::Duration;

struct SquareWave {
    phase_inc: f32,
    phase: f32,
    volume: f32,
    buffer: Vec<f32>
}

impl AudioCallback<f32> for SquareWave {
    fn callback(&mut self, stream: &mut AudioStreamInner, requested: i32) {
        self.buffer.resize(requested as usize, 0.0);

        // Generate a square wave
        for x in self.buffer.iter_mut() {
            *x = if self.phase <= 0.5 {
                self.volume
            } else {
                -self.volume
            };
            self.phase = (self.phase + self.phase_inc) % 1.0;
        }

        stream.put_data_f32(&self.buffer).unwrap();
    }
}

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let sdl_context = sdl3::init()?;
    let audio_subsystem = sdl_context.audio()?;

    let desired_spec = AudioSpec {
        freq: Some(48000),
        channels: Some(1), // mono
        format: Some(AudioFormat::f32_sys()),
    };

    let device = audio_subsystem.open_playback_stream(
        &desired_spec,
        SquareWave {
            phase_inc: 440.0 / desired_spec.freq.unwrap() as f32,
            phase: 0.0,
            volume: 0.25,
            buffer: Vec::new()
        },
    )?;

    // Start playback
    device.resume()?;

    // Play for 2 seconds
    std::thread::sleep(Duration::from_millis(2_000));

    // Device is automatically closed when dropped

    Ok(())
}
```