### PR TITLE
Replace GamepadSubsystem::num_gamepads in favor of GamepadSubsystem::gamepads

### DIFF
--- a/examples/game-controller.rs
+++ b/examples/game-controller.rs
@@ -8,14 +8,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sdl_context = sdl3::init()?;
     let gamepad_subsystem = sdl_context.gamepad()?;
 
-    let available = gamepad_subsystem
-        .num_gamepads()
+    let gamepad_joysticks_ids = gamepad_subsystem
+        .gamepads()
         .map_err(|e| format!("can't enumerate gamepads: {}", e))?;
 
-    println!("{} gamepads available", available);
+    println!("{} gamepads available", gamepad_joysticks_ids.len());
 
     // Iterate over all available joysticks and look for game controllers.
-    let mut controller = (0..available)
+    let mut controller = gamepad_joysticks_ids
+        .into_iter()
         .find_map(|id| {
             println!("Attempting to open gamepad {}", id);
 

--- a/examples/haptic.rs
+++ b/examples/haptic.rs
@@ -12,19 +12,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{} joysticks available", joysticks.len());
 
     // Iterate over all available joysticks and stop once we manage to open one.
-    let (_joystick, joystick_id) = joysticks
+    let joystick_id = joysticks
         .into_iter()
-        .find_map(|joystick| {
-            let id = joystick.id;
-            match joystick_subsystem.open(joystick) {
-                Ok(c) => {
-                    println!("Success: opened \"{}\"", c.name());
-                    Some((c, id))
-                }
-                Err(e) => {
-                    println!("failed: {:?}", e);
-                    None
-                }
+        .find_map(|id| match joystick_subsystem.open(id) {
+            Ok(c) => {
+                println!("Success: opened \"{}\"", c.name());
+                Some(id)
+            }
+            Err(e) => {
+                println!("failed: {:?}", e);
+                None
             }
         })
         .expect("Couldn't open any joystick");

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -15,7 +15,7 @@ use std::convert::TryInto;
 use crate::common::IntegerOrSdlError;
 use crate::get_error;
 use crate::guid::Guid;
-use crate::joystick::JoystickInstance;
+use crate::joystick::JoystickId;
 use crate::sys;
 use crate::Error;
 use crate::GamepadSubsystem;
@@ -59,7 +59,7 @@ impl error::Error for AddMappingError {
 impl GamepadSubsystem {
     /// Retrieve the total number of attached gamepads identified by SDL.
     #[doc(alias = "SDL_GetGamepads")]
-    pub fn gamepads(&self) -> Result<Vec<JoystickInstance>, Error> {
+    pub fn gamepads(&self) -> Result<Vec<JoystickId>, Error> {
         let mut num_gamepads: i32 = 0;
         unsafe {
             // see: https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_joystickh
@@ -81,7 +81,7 @@ impl GamepadSubsystem {
     /// Return true if the joystick at index `joystick_id` is a game controller.
     #[inline]
     #[doc(alias = "SDL_IsGamepad")]
-    pub fn is_game_controller(&self, joystick_id: JoystickInstance) -> bool {
+    pub fn is_game_controller(&self, joystick_id: JoystickId) -> bool {
         unsafe { sys::gamepad::SDL_IsGamepad(joystick_id) }
     }
 
@@ -89,7 +89,7 @@ impl GamepadSubsystem {
     /// Controller IDs are the same as joystick IDs and the maximum number can
     /// be retrieved using the `SDL_GetJoysticks` function.
     #[doc(alias = "SDL_OpenGamepad")]
-    pub fn open(&self, joystick_id: JoystickInstance) -> Result<Gamepad, IntegerOrSdlError> {
+    pub fn open(&self, joystick_id: JoystickId) -> Result<Gamepad, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let controller = unsafe { sys::gamepad::SDL_OpenGamepad(joystick_id) };
 
@@ -105,10 +105,7 @@ impl GamepadSubsystem {
 
     /// Return the name of the controller at index `joystick_id`.
     #[doc(alias = "SDL_GetGamepadNameForID")]
-    pub fn name_for_index(
-        &self,
-        joystick_id: JoystickInstance,
-    ) -> Result<String, IntegerOrSdlError> {
+    pub fn name_for_index(&self, joystick_id: JoystickId) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let c_str = unsafe { sys::gamepad::SDL_GetGamepadNameForID(joystick_id) };
 

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -15,6 +15,7 @@ use std::convert::TryInto;
 use crate::common::IntegerOrSdlError;
 use crate::get_error;
 use crate::guid::Guid;
+use crate::joystick::JoystickInstance;
 use crate::sys;
 use crate::Error;
 use crate::GamepadSubsystem;
@@ -57,35 +58,40 @@ impl error::Error for AddMappingError {
 
 impl GamepadSubsystem {
     /// Retrieve the total number of attached gamepads identified by SDL.
-    #[doc(alias = "SDL_GetJoysticks")]
-    pub fn num_gamepads(&self) -> Result<u32, Error> {
+    #[doc(alias = "SDL_GetGamepads")]
+    pub fn gamepads(&self) -> Result<Vec<JoystickInstance>, Error> {
         let mut num_gamepads: i32 = 0;
         unsafe {
             // see: https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_joystickh
             let gamepad_ids = sys::gamepad::SDL_GetGamepads(&mut num_gamepads);
-            if (gamepad_ids as *mut sys::gamepad::SDL_Gamepad).is_null() {
+            if gamepad_ids.is_null() {
                 Err(get_error())
             } else {
+                let mut instances = Vec::new();
+                for i in 0..num_gamepads {
+                    let id = *gamepad_ids.offset(i as isize);
+                    instances.push(id);
+                }
                 sys::stdinc::SDL_free(gamepad_ids as *mut c_void);
-                Ok(num_gamepads as u32)
+                Ok(instances)
             }
         }
     }
 
-    /// Return true if the joystick at index `joystick_index` is a game controller.
+    /// Return true if the joystick at index `joystick_id` is a game controller.
     #[inline]
     #[doc(alias = "SDL_IsGamepad")]
-    pub fn is_game_controller(&self, joystick_index: u32) -> bool {
-        unsafe { sys::gamepad::SDL_IsGamepad(joystick_index) }
+    pub fn is_game_controller(&self, joystick_id: JoystickInstance) -> bool {
+        unsafe { sys::gamepad::SDL_IsGamepad(joystick_id) }
     }
 
-    /// Attempt to open the controller at index `joystick_index` and return it.
+    /// Attempt to open the controller at index `joystick_id` and return it.
     /// Controller IDs are the same as joystick IDs and the maximum number can
     /// be retrieved using the `SDL_GetJoysticks` function.
     #[doc(alias = "SDL_OpenGamepad")]
-    pub fn open(&self, joystick_index: u32) -> Result<Gamepad, IntegerOrSdlError> {
+    pub fn open(&self, joystick_id: JoystickInstance) -> Result<Gamepad, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let controller = unsafe { sys::gamepad::SDL_OpenGamepad(joystick_index) };
+        let controller = unsafe { sys::gamepad::SDL_OpenGamepad(joystick_id) };
 
         if controller.is_null() {
             Err(SdlError(get_error()))
@@ -97,11 +103,14 @@ impl GamepadSubsystem {
         }
     }
 
-    /// Return the name of the controller at index `joystick_index`.
+    /// Return the name of the controller at index `joystick_id`.
     #[doc(alias = "SDL_GetGamepadNameForID")]
-    pub fn name_for_index(&self, joystick_index: u32) -> Result<String, IntegerOrSdlError> {
+    pub fn name_for_index(
+        &self,
+        joystick_id: JoystickInstance,
+    ) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let c_str = unsafe { sys::gamepad::SDL_GetGamepadNameForID(joystick_index) };
+        let c_str = unsafe { sys::gamepad::SDL_GetGamepadNameForID(joystick_id) };
 
         if c_str.is_null() {
             Err(SdlError(get_error()))

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -14,11 +14,7 @@ use sys::joystick::SDL_JoystickID;
 use sys::power::{SDL_PowerState, SDL_POWERSTATE_UNKNOWN};
 use sys::stdinc::SDL_free;
 
-pub struct JoystickInstance {
-    pub id: SDL_JoystickID,
-    name: String,
-    path: String,
-}
+pub type JoystickInstance = SDL_JoystickID;
 
 impl JoystickSubsystem {
     /// Get joystick instance IDs and names.
@@ -33,10 +29,7 @@ impl JoystickSubsystem {
                 let mut instances = Vec::new();
                 for i in 0..num_joysticks {
                     let id = *joystick_ids.offset(i as isize);
-
-                    let name = c_str_to_string(sys::joystick::SDL_GetJoystickNameForID(id));
-                    let path = c_str_to_string(sys::joystick::SDL_GetJoystickPathForID(id));
-                    instances.push(JoystickInstance { id, name, path });
+                    instances.push(id);
                 }
                 SDL_free(joystick_ids as *mut c_void);
                 Ok(instances)
@@ -46,9 +39,9 @@ impl JoystickSubsystem {
 
     /// Attempt to open the joystick at index `joystick_index` and return it.
     #[doc(alias = "SDL_OpenJoystick")]
-    pub fn open(&self, joystick_instance: JoystickInstance) -> Result<Joystick, IntegerOrSdlError> {
+    pub fn open(&self, joystick_id: JoystickInstance) -> Result<Joystick, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick = unsafe { sys::joystick::SDL_OpenJoystick(joystick_instance.id) };
+        let joystick = unsafe { sys::joystick::SDL_OpenJoystick(joystick_id) };
 
         if joystick.is_null() {
             Err(SdlError(get_error()))

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -14,12 +14,12 @@ use sys::joystick::SDL_JoystickID;
 use sys::power::{SDL_PowerState, SDL_POWERSTATE_UNKNOWN};
 use sys::stdinc::SDL_free;
 
-pub type JoystickInstance = SDL_JoystickID;
+pub type JoystickId = SDL_JoystickID;
 
 impl JoystickSubsystem {
     /// Get joystick instance IDs and names.
     #[doc(alias = "SDL_GetJoysticks")]
-    pub fn joysticks(&self) -> Result<Vec<JoystickInstance>, Error> {
+    pub fn joysticks(&self) -> Result<Vec<JoystickId>, Error> {
         let mut num_joysticks: i32 = 0;
         unsafe {
             let joystick_ids = sys::joystick::SDL_GetJoysticks(&mut num_joysticks);
@@ -39,7 +39,7 @@ impl JoystickSubsystem {
 
     /// Attempt to open the joystick at index `joystick_index` and return it.
     #[doc(alias = "SDL_OpenJoystick")]
-    pub fn open(&self, joystick_id: JoystickInstance) -> Result<Joystick, IntegerOrSdlError> {
+    pub fn open(&self, joystick_id: JoystickId) -> Result<Joystick, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
         let joystick = unsafe { sys::joystick::SDL_OpenJoystick(joystick_id) };
 


### PR DESCRIPTION
Making GamepadSubsystem match the original SDL3 interface: `num_gamepads` -> `gamepads`.

To avoid extra unneeded allocations, I've took the decision to remove the extra string fields from the `JoystickInstance` and rename it to `JoystickId`. It's just a type alias for now and it might be desired to have a complete type wrapping the `sys::joystick::JoystickID`, but I don't think it's necessary at this point or ever desired.