### PR TITLE
Fix multiple warnings

### DIFF
--- a/examples/audio-queue-squarewave.rs
+++ b/examples/audio-queue-squarewave.rs
@@ -23,7 +23,8 @@ fn gen_wave(bytes_to_write: i32) -> Vec<i16> {
 
 // FIXME
 fn main() -> () {}
-#[cfg(feature = "")]
+
+#[cfg(any())]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -15,7 +15,7 @@ struct Sound {
 }
 
 // FIXME: Adapt to new playback api.
-#[cfg(feature = "")]
+#[cfg(any())]
 impl AudioCallback<u8> for Sound {
     fn callback(&mut self, out: &[u8]) {
         for dst in out.iter_mut() {
@@ -40,7 +40,7 @@ impl AudioCallback<u8> for Sound {
 
 // FIXME: Convert to AudioStream library
 fn main() -> () {}
-#[cfg(feature = "")]
+#[cfg(any())]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wav_file: Cow<'static, Path> = match std::env::args().nth(1) {
         None => Cow::from(Path::new("./assets/sine.wav")),

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -20,7 +20,10 @@ impl AudioCallback<f32> for MyCallback {
             *x = (rng.gen_range(0.0..=2.0) - 1.0) * self.volume;
         }
 
-        stream.put_data_f32(&self.buffer);
+        match stream.put_data_f32(&self.buffer) {
+            Ok(()) => {}
+            Err(err) => println!("Failed to put data: {err}"),
+        }
     }
 }
 

--- a/examples/demo_games/a02_woodeneye_008.rs
+++ b/examples/demo_games/a02_woodeneye_008.rs
@@ -40,12 +40,12 @@ struct AppState {
 }
 
 // Function to find a player by their mouse ID
-fn whose_mouse(mouse: u32, players: &[Player], players_len: usize) -> Option<usize> {
+fn whose_mouse(mouse: u32, players: &[Player], _players_len: usize) -> Option<usize> {
     players.iter().position(|p| p.mouse == mouse)
 }
 
 // Function to find a player by their keyboard ID
-fn whose_keyboard(keyboard: u32, players: &[Player], players_len: usize) -> Option<usize> {
+fn whose_keyboard(keyboard: u32, players: &[Player], _players_len: usize) -> Option<usize> {
     players.iter().position(|p| p.keyboard == keyboard)
 }
 
@@ -256,7 +256,7 @@ fn draw_clipped_segment(
     let dy = ay - by;
 
     // Clip the first point (A) if it's behind the clipping plane
-    let (mut ax, mut ay, mut az) = if az > -w {
+    let (mut ax, mut ay, az) = if az > -w {
         let t = (-w - bz) / (az - bz); // Calculate intersection parameter
         (bx + dx * t, by + dy * t, -w) // Interpolate to the clipping plane
     } else {
@@ -264,7 +264,7 @@ fn draw_clipped_segment(
     };
 
     // Clip the second point (B) if it's behind the clipping plane
-    let (mut bx, mut by, mut bz) = if bz > -w {
+    let (mut bx, mut by, bz) = if bz > -w {
         let t = (-w - az) / (bz - az); // Calculate intersection parameter
         (ax - dx * t, ay - dy * t, -w) // Interpolate to the clipping plane
     } else {
@@ -584,8 +584,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         edges,
     };
 
-    let mut last_time = Instant::now();
+    // XXX: currently not in use, when we start using it delete the directive below
+    #[allow(unused_variables)]
     let mut accumulator = 0u64;
+
+    let mut last_time = Instant::now();
     let mut past_time = Instant::now();
 
     'running: loop {

--- a/examples/draw_triangle.rs
+++ b/examples/draw_triangle.rs
@@ -13,13 +13,7 @@ const WINDOW_HEIGHT: u32 = 600;
 
 // Function to fill a triangle
 
-fn fill_triangle(
-    canvas: &mut Canvas<Window>,
-    p1: (i32, i32),
-    p2: (i32, i32),
-    p3: (i32, i32),
-    color: Color,
-) {
+fn fill_triangle(canvas: &mut Canvas<Window>, p1: (i32, i32), p2: (i32, i32), p3: (i32, i32)) {
     let (x1, y1) = p1;
     let (x2, y2) = p2;
     let (x3, y3) = p3;
@@ -95,13 +89,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     canvas.clear();
 
     canvas.set_draw_color(Color::RGB(255, 0, 0));
-    fill_triangle(
-        &mut canvas,
-        (100, 100),
-        (200, 200),
-        (300, 100),
-        Color::RGB(255, 0, 0),
-    );
+    fill_triangle(&mut canvas, (100, 100), (200, 200), (300, 100));
 
     canvas.present();
 

--- a/examples/game-of-life.rs
+++ b/examples/game-of-life.rs
@@ -131,72 +131,74 @@ fn dummy_texture<'a>(
             (&mut square_texture1, TextureColor::Yellow),
             (&mut square_texture2, TextureColor::White),
         ];
-        canvas.with_multiple_texture_canvas(textures.iter(), |texture_canvas, user_context| {
-            texture_canvas.set_draw_color(Color::RGB(0, 0, 0));
-            texture_canvas.clear();
-            match *user_context {
-                TextureColor::Yellow => {
-                    for i in 0..SQUARE_SIZE {
-                        for j in 0..SQUARE_SIZE {
-                            if (i + j) % 4 == 0 {
-                                texture_canvas.set_draw_color(Color::RGB(255, 255, 0));
-                                texture_canvas
-                                    .draw_point(Point::new(i as i32, j as i32))
-                                    .expect("could not draw point");
-                            }
-                            if (i + j * 2) % 9 == 0 {
-                                texture_canvas.set_draw_color(Color::RGB(200, 200, 0));
-                                texture_canvas
-                                    .draw_point(Point::new(i as i32, j as i32))
-                                    .expect("could not draw point");
-                            }
-                        }
-                    }
-                }
-                TextureColor::White => {
-                    for i in 0..SQUARE_SIZE {
-                        for j in 0..SQUARE_SIZE {
-                            // drawing pixel by pixel isn't very effective, but we only do it once and store
-                            // the texture afterwards so it's still alright!
-                            if (i + j) % 7 == 0 {
-                                // this doesn't mean anything, there was some trial and error to find
-                                // something that wasn't too ugly
-                                texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
-                                texture_canvas
-                                    .draw_point(Point::new(i as i32, j as i32))
-                                    .expect("could not draw point");
-                            }
-                            if (i + j * 2) % 5 == 0 {
-                                texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
-                                texture_canvas
-                                    .draw_point(Point::new(i as i32, j as i32))
-                                    .expect("could not draw point");
+        canvas
+            .with_multiple_texture_canvas(textures.iter(), |texture_canvas, user_context| {
+                texture_canvas.set_draw_color(Color::RGB(0, 0, 0));
+                texture_canvas.clear();
+                match *user_context {
+                    TextureColor::Yellow => {
+                        for i in 0..SQUARE_SIZE {
+                            for j in 0..SQUARE_SIZE {
+                                if (i + j) % 4 == 0 {
+                                    texture_canvas.set_draw_color(Color::RGB(255, 255, 0));
+                                    texture_canvas
+                                        .draw_point(Point::new(i as i32, j as i32))
+                                        .expect("could not draw point");
+                                }
+                                if (i + j * 2) % 9 == 0 {
+                                    texture_canvas.set_draw_color(Color::RGB(200, 200, 0));
+                                    texture_canvas
+                                        .draw_point(Point::new(i as i32, j as i32))
+                                        .expect("could not draw point");
+                                }
                             }
                         }
                     }
-                }
-            };
-            for i in 0..SQUARE_SIZE {
-                for j in 0..SQUARE_SIZE {
-                    // drawing pixel by pixel isn't very effective, but we only do it once and store
-                    // the texture afterwards so it's still alright!
-                    if (i + j) % 7 == 0 {
-                        // this doesn't mean anything, there was some trial and serror to find
-                        // something that wasn't too ugly
-                        texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
-                        texture_canvas
-                            .draw_point(Point::new(i as i32, j as i32))
-                            .expect("could not draw point");
+                    TextureColor::White => {
+                        for i in 0..SQUARE_SIZE {
+                            for j in 0..SQUARE_SIZE {
+                                // drawing pixel by pixel isn't very effective, but we only do it once and store
+                                // the texture afterwards so it's still alright!
+                                if (i + j) % 7 == 0 {
+                                    // this doesn't mean anything, there was some trial and error to find
+                                    // something that wasn't too ugly
+                                    texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
+                                    texture_canvas
+                                        .draw_point(Point::new(i as i32, j as i32))
+                                        .expect("could not draw point");
+                                }
+                                if (i + j * 2) % 5 == 0 {
+                                    texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
+                                    texture_canvas
+                                        .draw_point(Point::new(i as i32, j as i32))
+                                        .expect("could not draw point");
+                                }
+                            }
+                        }
                     }
-                    if (i + j * 2) % 5 == 0 {
-                        texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
-                        texture_canvas
-                            .draw_point(Point::new(i as i32, j as i32))
-                            .expect("could not draw point");
+                };
+                for i in 0..SQUARE_SIZE {
+                    for j in 0..SQUARE_SIZE {
+                        // drawing pixel by pixel isn't very effective, but we only do it once and store
+                        // the texture afterwards so it's still alright!
+                        if (i + j) % 7 == 0 {
+                            // this doesn't mean anything, there was some trial and serror to find
+                            // something that wasn't too ugly
+                            texture_canvas.set_draw_color(Color::RGB(192, 192, 192));
+                            texture_canvas
+                                .draw_point(Point::new(i as i32, j as i32))
+                                .expect("could not draw point");
+                        }
+                        if (i + j * 2) % 5 == 0 {
+                            texture_canvas.set_draw_color(Color::RGB(64, 64, 64));
+                            texture_canvas
+                                .draw_point(Point::new(i as i32, j as i32))
+                                .expect("could not draw point");
+                        }
                     }
                 }
-            }
-        });
+            })
+            .unwrap();
     }
     Ok((square_texture1, square_texture2))
 }

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -4,6 +4,7 @@ use std::ptr;
 use sdl3::properties::*;
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct TestData<'a> {
     pub hello: &'a str,
     pub goodbye: &'a str,

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -38,13 +38,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         angle = (angle + 0.5) % 360.;
-        canvas.with_texture_canvas(&mut texture, |texture_canvas| {
-            texture_canvas.clear();
-            texture_canvas.set_draw_color(Color::RGBA(255, 0, 0, 255));
-            texture_canvas
-                .fill_rect(FRect::new(0.0, 0.0, 400.0, 300.0))
-                .expect("could not fill rect");
-        });
+        canvas
+            .with_texture_canvas(&mut texture, |texture_canvas| {
+                texture_canvas.clear();
+                texture_canvas.set_draw_color(Color::RGBA(255, 0, 0, 255));
+                texture_canvas
+                    .fill_rect(FRect::new(0.0, 0.0, 400.0, 300.0))
+                    .expect("could not fill rect");
+            })
+            .unwrap();
         canvas.set_draw_color(Color::RGBA(0, 0, 0, 255));
         let dst = Some(FRect::new(0.0, 0.0, 400.0, 300.0));
         canvas.clear();

--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -91,7 +91,7 @@ impl AudioSubsystem {
         F: FnOnce(&mut i32) -> *mut sys::audio::SDL_AudioDeviceID,
     {
         let mut num_devices: i32 = 0;
-        let devices = unsafe { get_devices(&mut num_devices) };
+        let devices = get_devices(&mut num_devices);
         if devices.is_null() {
             return Err(get_error());
         }

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -1,6 +1,5 @@
 use libc::{c_char, c_void};
 
-use std::convert::Into;
 use std::error;
 use std::ffi::{CStr, CString, NulError};
 use std::fmt;

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -21,8 +21,6 @@ use crate::sys;
 use crate::Error;
 use crate::GamepadSubsystem;
 
-use sys::joystick::SDL_GetJoystickID;
-
 #[derive(Debug, Clone)]
 pub enum AddMappingError {
     InvalidMapping(NulError),

--- a/src/sdl3/gpu/device.rs
+++ b/src/sdl3/gpu/device.rs
@@ -225,7 +225,8 @@ impl Device {
         unsafe { std::mem::transmute(sys::gpu::SDL_GetGPUShaderFormats(self.raw())) }
     }
 
-    #[cfg(target_os = "xbox")]
+    // NOTE: for Xbox builds, the target is a UWP, e.g.: x86_64-uwp-windows-msvc
+    #[cfg(target_vendor = "uwp")]
     #[doc(alias = "SDL_GDKSuspendGPU")]
     pub fn gdk_suspend(&self) {
         unsafe {
@@ -233,7 +234,7 @@ impl Device {
         }
     }
 
-    #[cfg(target_os = "xbox")]
+    #[cfg(target_vendor = "uwp")]
     #[doc(alias = "SDL_GDKResumeGPU")]
     pub fn gdk_resume(&self) {
         unsafe {

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -10,12 +10,10 @@ use crate::JoystickSubsystem;
 use libc::{c_char, c_void};
 use std::ffi::CStr;
 use std::fmt;
-use sys::joystick::SDL_JoystickConnectionState;
-use sys::joystick::SDL_JoystickID;
 use sys::power::{SDL_PowerState, SDL_POWERSTATE_UNKNOWN};
 use sys::stdinc::SDL_free;
 
-pub type JoystickId = SDL_JoystickID;
+pub type JoystickId = sys::joystick::SDL_JoystickID;
 
 impl JoystickSubsystem {
     /// Get joystick instance IDs and names.

--- a/src/sdl3/timer.rs
+++ b/src/sdl3/timer.rs
@@ -95,7 +95,7 @@ impl Drop for Timer {
 
 extern "C" fn c_timer_callback(
     userdata: *mut c_void,
-    _timerID: sys::timer::SDL_TimerID,
+    _timer_id: sys::timer::SDL_TimerID,
     _interval: u32,
 ) -> u32 {
     let callback_ptr = userdata as *mut TimerCallback;

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1280,6 +1280,8 @@ impl WindowBuilder {
 
             let raw = sys::video::SDL_CreateWindowWithProperties(props);
             SDL_DestroyProperties(props);
+
+            #[allow(unused_mut)]
             let mut metal_view = 0 as sys::metal::SDL_MetalView;
             #[cfg(target_os = "macos")]
             if self.create_metal_view {
@@ -1463,6 +1465,8 @@ impl PopupWindowBuilder {
                 raw_height,
                 self.window_flags.into(),
             );
+
+            #[allow(unused_mut)]
             let mut metal_view = 0 as sys::metal::SDL_MetalView;
             #[cfg(target_os = "macos")]
             if self.create_metal_view {


### PR DESCRIPTION
Fix multiple warnings that are polluting the build.

Warnings in audio examples were not fixed since these examples are just broken right now. I'll tackle audio+mixer as a next step.