### PR TITLE
Take &CStr in some builders to avoid redundant allocation

### DIFF
--- a/examples/gpu-cube.rs
+++ b/examples/gpu-cube.rs
@@ -103,7 +103,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             ShaderStage::Vertex,
         )
         .with_uniform_buffers(1)
-        .with_entrypoint("main")
+        .with_entrypoint(c"main")
         .build()?;
     let frag_shader = gpu
         .create_shader()
@@ -112,7 +112,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             include_bytes!("shaders/cube.frag.spv"),
             ShaderStage::Fragment,
         )
-        .with_entrypoint("main")
+        .with_entrypoint(c"main")
         .build()?;
 
     // Create a pipeline, we specify that we want our target format in the swapchain

--- a/examples/gpu-texture.rs
+++ b/examples/gpu-texture.rs
@@ -208,7 +208,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             ShaderStage::Vertex,
         )
         .with_uniform_buffers(1)
-        .with_entrypoint("main")
+        .with_entrypoint(c"main")
         .build()?;
     let frag_shader = gpu
         .create_shader()
@@ -218,7 +218,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             ShaderStage::Fragment,
         )
         .with_samplers(1)
-        .with_entrypoint("main")
+        .with_entrypoint(c"main")
         .build()?;
 
     // Create a pipeline, we specify that we want our target format in the swapchain

--- a/examples/gpu-triangle.rs
+++ b/examples/gpu-triangle.rs
@@ -37,13 +37,13 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vs_shader = gpu
         .create_shader()
         .with_code(ShaderFormat::SpirV, vs_source, ShaderStage::Vertex)
-        .with_entrypoint("main")
+        .with_entrypoint(c"main")
         .build()?;
 
     let fs_shader = gpu
         .create_shader()
         .with_code(ShaderFormat::SpirV, fs_source, ShaderStage::Fragment)
-        .with_entrypoint("main")
+        .with_entrypoint(c"main")
         .build()?;
 
     let swapchain_format = gpu.get_swapchain_texture_format(&window);

--- a/src/sdl3/gpu/pipeline.rs
+++ b/src/sdl3/gpu/pipeline.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     sys, Error,
 };
-use std::{ffi::CString, sync::Arc};
+use std::{ffi::CStr, sync::Arc};
 use sys::gpu::{
     SDL_GPUBlendFactor, SDL_GPUBlendOp, SDL_GPUColorTargetBlendState,
     SDL_GPUColorTargetDescription, SDL_GPUCompareOp, SDL_GPUComputePipeline,
@@ -452,14 +452,12 @@ impl DepthStencilState {
 #[repr(C)]
 pub struct ComputePipelineBuilder<'a> {
     device: &'a Device,
-    entrypoint: CString,
     inner: SDL_GPUComputePipelineCreateInfo,
 }
 impl<'a> ComputePipelineBuilder<'a> {
     pub(super) fn new(device: &'a Device) -> Self {
         Self {
             device,
-            entrypoint: CString::new("main").unwrap(),
             inner: Default::default(),
         }
     }
@@ -471,9 +469,8 @@ impl<'a> ComputePipelineBuilder<'a> {
         self
     }
 
-    pub fn with_entrypoint(mut self, entry_point: &'a str) -> Self {
-        self.entrypoint = CString::new(entry_point).unwrap(); //need to save
-        self.inner.entrypoint = self.entrypoint.as_c_str().as_ptr();
+    pub fn with_entrypoint(mut self, entry_point: &'a CStr) -> Self {
+        self.inner.entrypoint = entry_point.as_ptr();
         self
     }
 

--- a/src/sdl3/gpu/shader.rs
+++ b/src/sdl3/gpu/shader.rs
@@ -3,7 +3,7 @@ use crate::{
     gpu::{Device, ShaderFormat, ShaderStage, WeakDevice},
     Error,
 };
-use std::{ffi::CString, sync::Arc};
+use std::{ffi::CStr, sync::Arc};
 use sys::gpu::{SDL_GPUShader, SDL_GPUShaderCreateInfo};
 
 /// Manages the raw `SDL_GPUShader` pointer and releases it on drop
@@ -32,14 +32,12 @@ impl Shader {
 
 pub struct ShaderBuilder<'a> {
     device: &'a Device,
-    entrypoint: CString,
     inner: SDL_GPUShaderCreateInfo,
 }
 impl<'a> ShaderBuilder<'a> {
     pub(super) fn new(device: &'a Device) -> Self {
         Self {
             device,
-            entrypoint: CString::new("main").unwrap(),
             inner: Default::default(),
         }
     }
@@ -71,9 +69,8 @@ impl<'a> ShaderBuilder<'a> {
         self.inner.stage = unsafe { std::mem::transmute(stage as u32) };
         self
     }
-    pub fn with_entrypoint(mut self, entry_point: &'a str) -> Self {
-        self.entrypoint = CString::new(entry_point).unwrap(); //need to save
-        self.inner.entrypoint = self.entrypoint.as_c_str().as_ptr();
+    pub fn with_entrypoint(mut self, entry_point: &'a CStr) -> Self {
+        self.inner.entrypoint = entry_point.as_ptr();
         self
     }
     pub fn build(self) -> Result<Shader, Error> {


### PR DESCRIPTION
ShaderBuilder::[with_entrypoint](https://docs.rs/sdl3/latest/sdl3/gpu/struct.ShaderBuilder.html#method.with_entrypoint) and ComputePipelineBuilder::[with_entrypoint](https://docs.rs/sdl3/latest/sdl3/gpu/struct.ComputePipelineBuilder.html#method.with_entrypoint) were taking a regular rust `&str`, but because the underlying SDL-calls want a nul-terminated string, these wrappers had to allocate. Taking `&CStr` avoids all the hassle, and most callsites will just change from `.with_entrypoint("foo")` to `.with_entrypoint(c"foo")`.

This is a breaking change, though both APIs are very recent additions. A similar change was made in https://github.com/vhspace/sdl3-rs/pull/129 .

I looked into these after getting segfaults when calling `build` without a call to `with_entrypoint`. That is due to the default construction leaving the pointer null. I did *not* change that, since based on the recent https://github.com/libsdl-org/SDL/pull/12542/commits/7a3a675eeee78870ca88bb0bb0005eac5adcc0ef it looks like SDL intends to interpret a null pointer as a default value.