### PR TITLE
added missing keycode values on event.rs tests

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -2866,7 +2866,7 @@ mod test {
             let e = Event::KeyDown {
                 timestamp: 0,
                 window_id: 1,
-                keycode: None,
+                keycode: Some(Keycode::Q),
                 scancode: Some(Scancode::Q),
                 keymod: Mod::all(),
                 repeat: false,
@@ -3057,7 +3057,7 @@ mod test {
         let mut raw_event = Event::KeyDown {
             timestamp: 0,
             window_id: 1,
-            keycode: None,
+            keycode: Some(Keycode::Q),
             scancode: Some(Scancode::Q),
             keymod: Mod::empty(),
             repeat: false,
@@ -3084,7 +3084,7 @@ mod test {
         let mut raw_event = Event::KeyUp {
             timestamp: 0,
             window_id: 1,
-            keycode: None,
+            keycode: Some(Keycode::Q),
             scancode: Some(Scancode::Q),
             keymod: Mod::empty(),
             repeat: false,


### PR DESCRIPTION
fixes https://github.com/vhspace/sdl3-rs/issues/104

See https://github.com/vhspace/sdl3-rs/issues/104#issuecomment-2781557086 for an explanation. This PR assumes that the called code should always be passed a `keycode`, which from a quick search through SDL docs appears to be the case.

This doesn't fix all tests, but the next test that fails deals with a different issue, so I am opening this separate pull request already.