### PR TITLE
Pass `Event::User.type_` to `SDL_UserEvent.r#type` in `Event::to_ll`

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -1010,14 +1010,14 @@ impl Event {
         match *self {
             Event::User {
                 window_id,
-                type_: _,
+                type_,
                 code,
                 data1,
                 data2,
                 timestamp,
             } => {
                 let event = sys::events::SDL_UserEvent {
-                    r#type: sys::events::SDL_EVENT_USER.into(),
+                    r#type: type_,
                     timestamp,
                     windowID: window_id,
                     code,

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -2866,7 +2866,7 @@ mod test {
             let e = Event::KeyDown {
                 timestamp: 0,
                 window_id: 1,
-                keycode: None,
+                keycode: Some(Keycode::Q),
                 scancode: Some(Scancode::Q),
                 keymod: Mod::all(),
                 repeat: false,
@@ -3057,7 +3057,7 @@ mod test {
         let mut raw_event = Event::KeyDown {
             timestamp: 0,
             window_id: 1,
-            keycode: None,
+            keycode: Some(Keycode::Q),
             scancode: Some(Scancode::Q),
             keymod: Mod::empty(),
             repeat: false,
@@ -3084,7 +3084,7 @@ mod test {
         let mut raw_event = Event::KeyUp {
             timestamp: 0,
             window_id: 1,
-            keycode: None,
+            keycode: Some(Keycode::Q),
             scancode: Some(Scancode::Q),
             keymod: Mod::empty(),
             repeat: false,


### PR DESCRIPTION
fixes https://github.com/vhspace/sdl3-rs/issues/155

My rationale for the suggested change is explained in my comments in the same issue.

---

After applying this change, all `src/sdl3/event.rs` tests are green, but the following modules report FAILED tests.
However, this seems to be because they weren't ran prior to this change, rather than a regression.

```
src/sdl3/audio.rs
src/sdl3/keyboard/mod.rs
src/sdl3/render.rs
src/sdl3/surface.rs
src/sdl3/video.rs
```