### PR TITLE
Fix features for optional dependencies: Don't depend on crates that haven't been enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,13 +67,13 @@ static-link = ["sdl3-sys/link-static"]
 link-framework = ["sdl3-sys/link-framework"]
 build-from-source = [
     "sdl3-sys/build-from-source",
-    "sdl3-image-sys/build-from-source",
-    "sdl3-ttf-sys/build-from-source",
+    "sdl3-image-sys?/build-from-source",
+    "sdl3-ttf-sys?/build-from-source",
 ]
 build-from-source-static = [
     "sdl3-sys/build-from-source-static",
-    "sdl3-image-sys/build-from-source-static",
-    "sdl3-ttf-sys/build-from-source-static",
+    "sdl3-image-sys?/build-from-source-static",
+    "sdl3-ttf-sys?/build-from-source-static",
 ]
 build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]


### PR DESCRIPTION
The `build-from-source` and `build-from-source-static` features would always depend on the `sdl3-image-sys` and `sdl3-ttf-sys` crates. This PR fixes that.