### PR TITLE
Fix buffer overrun in create_window_and_renderer

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -876,9 +876,11 @@ impl VideoSubsystem {
     ) -> Result<WindowCanvas, Error> {
         let mut sdl_window = null_mut();
         let mut renderer = null_mut();
+
+        let title = CString::new(title).unwrap();
         let result = unsafe {
             sys::render::SDL_CreateWindowAndRenderer(
-                title.as_ptr() as *const c_char,
+                title.as_ptr(),
                 width as c_int,
                 height as c_int,
                 0,


### PR DESCRIPTION
The previous code simply unsafely cast the given title `&str` into a `* const c_char`, which immediately caused a buffer overrun in my case and the title was a garbled mess that only happened to stop because there was a nul in the way. The new code fixes this by creating a CString as was probably meant. I'm not sure how this hadn't been hit before.

Since creating a CString can fail, to prevent API breakage I just unwrap it. Maybe it should instead return a WindowBuilderError with the InvalidTitle variant but that would break the API. Might not be worth it when I can't imagine a reasonable use-case for the title having a nul…

Also, casting width and height to c_int can also cause overflow. But that's less of an issue as SDL will probably just crash.

Cheers