### PR TITLE
Fix compiling with Ash feature

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1709,7 +1709,7 @@ impl Window {
         let mut surface: VkSurfaceKHR = VkSurfaceKHR::default();
 
         #[cfg(not(feature = "ash"))]
-        let mut surface: VkSurfaceKHR = 0 as _;
+        let mut surface: VkSurfaceKHR = VkSurfaceKHR::null();
         if unsafe {
             sys::vulkan::SDL_Vulkan_CreateSurface(self.context.raw, instance, null(), &mut surface)
         } {


### PR DESCRIPTION
Fix compiling with Ash (Vulkan lib) feature enabled. '0 as _;' was givin errors.

rustc 1.86.0 (05f9846f8 2025-03-31)
Platform: Windows
ash = "0.38.0"
sdl3 = { version = "0.14.27", features = ["build-from-source-static"] }
sdl3-sys = { version = "0.5.1", features = ["build-from-source-static", "use-ash-v0-38"] }