### PR TITLE
enable raw-window-handle feature for docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ raw-window-handle = ["dep:raw-window-handle", "dep:objc2"]
 [package.metadata.docs.rs]
 #features = ["default", "gfx", "mixer", "image", "ttf"]
 #features = ["default", "gfx"]
-features = ["default"]
+features = ["default", "raw-window-handle"]
 
 [[example]]
 name = "animation"

--- a/README.md
+++ b/README.md
@@ -46,24 +46,10 @@ Add the following to your `Cargo.toml`:
 sdl3 = { version = "0", features = [] }
 ```
 
-## Linking to SDL3
-
-This crate requires the SDL3 system library to link and run.
-
-By default without any of these features enabled, it will try to link a system SDL3 library as a dynamic/shared library
-using the default library search paths.
-
-You may select how to link the library via features:
-
-- `build-from-source`: Fetch and build the library from source. Recommended if you just want it to work and don't have
-  SDL3 installed system-wide.
-- `build-from-source-static`: Fetch and build the library from source and link it statically.
-- `use-pkg-config`: Use `pkg-config` to find the library.
-- `use-vcpkg`: Use `vcpkg` to find the library.
-- `static-link`: Link the library statically.
-- `link-framework`: Link the library as a framework on macOS.
-
-You can read more about these options [here](https://github.com/maia-s/sdl3-sys-rs/tree/main/sdl3-sys#usage).
+For further instructions either checkout the documentation of the different
+build/feature flags on [`docs.rs`](https://docs.rs/sdl3/latest/sdl3/), or if you
+want to access the documentation locally, run `cargo doc --open` in your project
+and search for `sdl3`.
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ Add the following to your `Cargo.toml`:
 sdl3 = { version = "0", features = [] }
 ```
 
-For further instructions either checkout the documentation of the different
-build/feature flags on [`docs.rs`](https://docs.rs/sdl3/latest/sdl3/), or if you
-want to access the documentation locally, run `cargo doc --open` in your project
-and search for `sdl3`.
+### [Read the documentation](https://docs.rs/sdl3/latest/sdl3/)
+
+Or if you would like to open it offline, run `cargo doc --package sdl3 --open`
 
 # Documentation
 

--- a/src/sdl3/lib.rs
+++ b/src/sdl3/lib.rs
@@ -44,6 +44,47 @@
 //!     }
 //! }
 //! ```
+//!
+//! # Feature Flags
+//!
+//! ## Linking to `libsdl3`
+//!
+//! This crate requires the SDL3 library to link and run.
+//!
+//! By default without any of these features enabled, it will try to link a system SDL3 library as a dynamic/shared library
+//! using the default library search paths.
+//!
+//! If you don't have `libsdl3` installed on your system and just want it to work, we recommend using `build-from-source`.
+//! Also see the different build configurations that `sdl3-sys` provides:  <https://github.com/maia-s/sdl3-sys-rs/tree/main/sdl3-sys#usage>
+//!
+//! | Name                             | Description                                                    |
+//! |----------------------------------|----------------------------------------------------------------|
+//! | `build-from-source`              | Fetch and build the library from source                        |
+//! | `build-from-source-static`       | Fetch and build the library from source and link it statically |
+//! | `build-from-source-unix-console` | TODO                                                           |
+//! | `use-pkg-config`                 | Use `pkg-config` to find the library                           |
+//! | `use-vcpkg`                      | Use `vcpkg` to find the library                                |
+//! | `static-link`                    | Link the library statically                                    |
+//! | `link-framework`                 | Link the library as a framework on macOS                       |
+//!
+//! ## Optional Features
+//!
+//! Note that since `sdl3` is still in the progress of migrating to and integrating the new
+//! features of `libsdl3`, some features might be not yet, or only partially implemented.
+//!
+//! | Name                | Description                                                            | Implementation Status |
+//! |---------------------|------------------------------------------------------------------------|-----------------------|
+//! | `ash`               | Use Vulkan types from the ash crate                                    | Implemented           |
+//! | `unsafe_textures`   | TODO                                                                   | TODO                  |
+//! | `gfx`               | TODO                                                                   | TODO                  |
+//! | `mixer`             | TODO                                                                   | Not Implemented?      |
+//! | `image`             | TODO                                                                   | TODO                  |
+//! | `ttf`               | TODO                                                                   | TODO                  |
+//! | `hidapi`            | Use hidapi support in SDL                                              | TODO                  |
+//! | `test-mode`         | Allows SDL to be initialised from a thread that is not the main thread | Implemented           |
+//! | `raw-window-handle` | Enables integrations with the [`wgpu`] crate                           | Implemented           |
+//!
+//! [`wgpu`]: https://docs.rs/wgpu/latest/wgpu/
 
 #![crate_name = "sdl3"]
 #![crate_type = "lib"]


### PR DESCRIPTION
A friend (@skoove) and I were trying to figure out how to setup `wgpu` with `sdl3` and had
some trouble to figure out whether there even is support and if yes, how to
enable it.

Seeing the impls of `HasDisplayHandle` and `HasWindowHandle` in on <https://docs.rs/> would have helped a
lot for that 🙂

Related to that: Would it be a good idea to document `sdl3`'s feature flags as
part of the `lib.rs`?

I don't actively work with sdl3, so I'm not sure how helpful I could be in
writing it/helping to write it, but at least listing the basic features in a
table with a short description and considering that the crate is still being
migrated over to SDL3, maybe a word to the implementation status would be
extremely helpful.
