### PR TITLE
TTF refactor

### DIFF
--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -59,7 +59,7 @@ fn run(font_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let texture_creator = canvas.texture_creator();
 
     // Load a font
-    let mut font = ttf_context.load_font(font_path, 128)?;
+    let mut font = ttf_context.load_font(font_path, 128.0)?;
     font.set_style(sdl3::ttf::FontStyle::BOLD);
 
     // render a surface, and convert it to a texture bound to the canvas
@@ -85,7 +85,7 @@ fn run(font_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         SCREEN_HEIGHT - padding,
     );
 
-    canvas.copy(&texture, None, Some(target))?;
+    canvas.copy(&texture, None, Some(target.into()))?;
     canvas.present();
 
     'mainloop: loop {

--- a/src/sdl3/ttf/font.rs
+++ b/src/sdl3/ttf/font.rs
@@ -287,7 +287,7 @@ pub fn internal_load_font<'ttf, P: AsRef<Path>>(
             Err(get_error())
         } else {
             Ok(Font {
-                raw: raw,
+                raw,
                 iostream: None,
                 _marker: PhantomData,
             })
@@ -304,7 +304,7 @@ where
     R: Into<Option<IOStream<'r>>>,
 {
     Font {
-        raw: raw,
+        raw,
         iostream: iostream.into(),
         _marker: PhantomData,
     }
@@ -347,7 +347,7 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
             let ret = ttf::TTF_GetStringSize(self.raw, c_string.as_ptr(), 0, &mut w, &mut h);
             (ret, (w as u32, h as u32))
         };
-        if res == true {
+        if res {
             Ok(size)
         } else {
             Err(FontError::SdlError(get_error()))
@@ -465,7 +465,7 @@ impl<'ttf, 'r> Font<'ttf, 'r> {
     pub fn find_glyph(&self, ch: char) -> Option<u16> {
         unsafe {
             let ret = ttf::TTF_FontHasGlyph(self.raw, ch as u32);
-            if ret {
+            if !ret {
                 None
             } else {
                 Some(ret as u16)

--- a/src/sdl3/ttf/mod.rs
+++ b/src/sdl3/ttf/mod.rs
@@ -25,9 +25,7 @@ mod font;
 
 pub use sdl3_ttf_sys::ttf as sys;
 
-pub use self::context::{
-    get_linked_version, has_been_initialized, init, InitError, Sdl3TtfContext,
-};
+pub use self::context::{get_linked_version, has_been_initialized, init, Sdl3TtfContext};
 pub use self::font::{
     Font, FontError, FontResult, FontStyle, GlyphMetrics, Hinting, PartialRendering,
 };


### PR DESCRIPTION
The TTF feature is not matching the whole crate design since `rust-sdl2`. Got quite annoyed today by the unnecessary lifetime in `Font`, so decided to fix it and make the TTF context work like the SDL subsystems.

Changes:
- Refactor Sdl3TtfContext initialization and cleanup use the same logic with atomics that subsystems use: it's way safer (there's no change to do double initialization) and allows the next refactor to be possible.
- Refactored Font to not require a lifetime. This was only required since the TTF context could be dropped at any time. Now the font doesn't need to track the context's lifetime since it will keep the context alive as well.
- Small fixes and documentation done

Future:
I also hate the IOStream inside the Font that requires another lifetime. I'm not sure how to get rid of it, but at least for my personal use-case I can just use the `'static` lifetime since I don't use the IOStream at all and don't view too much value in it right now.