### PR TITLE
feat(gpu): Add swapchain presentation and composition control

### DIFF
--- a/src/sdl3/gpu/enums.rs
+++ b/src/sdl3/gpu/enums.rs
@@ -422,3 +422,22 @@ pub enum ColorComponentFlags {
     ABit = SDL_GPU_COLORCOMPONENT_A,
 }
 impl_with!(bitwise_and_or ColorComponentFlags u8);
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum PresentMode {
+    #[default]
+    Vsync = sys::gpu::SDL_GPU_PRESENTMODE_VSYNC.0 as u32,
+    Immediate = sys::gpu::SDL_GPU_PRESENTMODE_IMMEDIATE.0 as u32,
+    Mailbox = sys::gpu::SDL_GPU_PRESENTMODE_MAILBOX.0 as u32,
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SwapchainComposition {
+    #[default]
+    Sdr = sys::gpu::SDL_GPU_SWAPCHAINCOMPOSITION_SDR.0 as u32,
+    SdrLinear = sys::gpu::SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR.0 as u32,
+    HdrExtendedLinear = sys::gpu::SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR.0 as u32,
+    Hdr10St2084 = sys::gpu::SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084.0 as u32,
+}

--- a/src/sdl3/gpu/mod.rs
+++ b/src/sdl3/gpu/mod.rs
@@ -12,9 +12,10 @@ pub use device::Device;
 mod enums;
 pub use enums::{
     BlendFactor, BlendOp, BufferUsageFlags, ColorComponentFlags, CompareOp, CullMode, FillMode,
-    Filter, FrontFace, IndexElementSize, LoadOp, PrimitiveType, SampleCount, SamplerAddressMode,
-    SamplerMipmapMode, ShaderFormat, ShaderStage, StencilOp, StoreOp, TextureFormat, TextureType,
-    TextureUsage, TransferBufferUsage, VertexElementFormat, VertexInputRate,
+    Filter, FrontFace, IndexElementSize, LoadOp, PresentMode, PrimitiveType, SampleCount,
+    SamplerAddressMode, SamplerMipmapMode, ShaderFormat, ShaderStage, StencilOp, StoreOp,
+    SwapchainComposition, TextureFormat, TextureType, TextureUsage, TransferBufferUsage,
+    VertexElementFormat, VertexInputRate,
 };
 
 mod pass;


### PR DESCRIPTION
**What's added:**
* `PresentMode` enum: A Rust-idiomatic binding for `SDL_GPUPresentMode`, allowing control over frame presentation behavior (VSync, tearing, etc.).
* `SwapchainComposition` enum: A Rust-idiomatic binding for `SDL_GPUSwapchainComposition`, enabling control over how colors are composed for display, particularly relevant for HDR output.
* `Device::set_swapchain_parameters` function: A safe Rust wrapper around the `SDL_SetGPUSwapchainParameters` C function, utilizing the new enums to set the desired presentation and composition modes for a given `Window` and `Device`.