### PR TITLE
Make VideoSubsystem::window_from_id unsafe

### DIFF
--- a/tests/video.rs
+++ b/tests/video.rs
@@ -17,3 +17,38 @@ fn display_name_no_segfault() {
       // so ignore it
 }
 */
+
+use sdl3::render::Canvas;
+use sdl3::video::Window;
+use sdl3::VideoSubsystem;
+
+fn build_canvas(video_subsystem: VideoSubsystem) -> Canvas<Window> {
+    let window = video_subsystem
+        .window("rust-sdl3 test: Video", 800, 600)
+        .resizable()
+        .position_centered()
+        .opengl()
+        .build()
+        .map_err(|e| e.to_string())
+        .unwrap();
+
+    let mut canvas = window.into_canvas();
+
+    canvas.clear();
+    canvas
+}
+
+#[test]
+fn window_from_id() {
+    let sdl_context = sdl3::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+
+    let canvas = build_canvas(video_subsystem.clone());
+
+    let mut window = unsafe {
+        video_subsystem
+            .window_from_id(canvas.window().id())
+            .unwrap()
+    };
+    window.maximize();
+}


### PR DESCRIPTION
From the discussion on Discord, this function was just wrong.
I've been thinking to implement what "SomePerson" commented and have VideoSubsystem keep track of the WindowContexts, but since this is the only function right now that can violate safety, I might keep it on hold and only do it if/when we add all missing Window functionality.