### PR TITLE
Replace gpu enums with bitflags

### DIFF
--- a/examples/gpu-clear.rs
+++ b/examples/gpu-clear.rs
@@ -17,7 +17,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // by default, and we specify that our shaders will be SPIR-V ones (even through we
     // aren't using any shaders)
     // We'll also turn on debug mode to true, so we get debug stuff
-    let gpu = sdl3::gpu::Device::new(sdl3::gpu::ShaderFormat::SpirV, true)?.with_window(&window)?;
+    let gpu = sdl3::gpu::Device::new(sdl3::gpu::ShaderFormat::SPIRV, true)?.with_window(&window)?;
 
     let mut event_pump = sdl_context.event_pump()?;
     println!(
@@ -45,8 +45,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             let color_targets = [
                 sdl3::gpu::ColorTargetInfo::default()
                     .with_texture(&swapchain) // Use swapchain texture
-                    .with_load_op(sdl3::gpu::LoadOp::Clear) // Clear when load
-                    .with_store_op(sdl3::gpu::StoreOp::Store) // Store back
+                    .with_load_op(sdl3::gpu::LoadOp::CLEAR) // Clear when load
+                    .with_store_op(sdl3::gpu::StoreOp::STORE) // Store back
                     .with_clear_color(sdl3::pixels::Color::RGB(5, 3, 255)), //blue with small RG bias
             ];
             // Here we do all (none) of our drawing (clearing the screen)

--- a/examples/gpu-cube.rs
+++ b/examples/gpu-cube.rs
@@ -89,7 +89,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| e.to_string())?;
 
     let gpu = Device::new(
-        ShaderFormat::SpirV | ShaderFormat::Dxil | ShaderFormat::Dxbc | ShaderFormat::MetalLib,
+        ShaderFormat::SPIRV | ShaderFormat::DXIL | ShaderFormat::DXBC | ShaderFormat::METALLIB,
         true,
     )?
     .with_window(&window)?;
@@ -98,7 +98,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vert_shader = gpu
         .create_shader()
         .with_code(
-            ShaderFormat::SpirV,
+            ShaderFormat::SPIRV,
             include_bytes!("shaders/cube.vert.spv"),
             ShaderStage::Vertex,
         )
@@ -108,7 +108,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let frag_shader = gpu
         .create_shader()
         .with_code(
-            ShaderFormat::SpirV,
+            ShaderFormat::SPIRV,
             include_bytes!("shaders/cube.frag.spv"),
             ShaderStage::Fragment,
         )
@@ -171,7 +171,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let transfer_buffer = gpu
         .create_transfer_buffer()
         .with_size(vertices_len_bytes.max(indices_len_bytes) as u32)
-        .with_usage(TransferBufferUsage::Upload)
+        .with_usage(TransferBufferUsage::UPLOAD)
         .build()?;
 
     // We need to start a copy pass in order to transfer data to the GPU
@@ -183,14 +183,14 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         &gpu,
         &transfer_buffer,
         &copy_pass,
-        BufferUsageFlags::Vertex,
+        BufferUsageFlags::VERTEX,
         &CUBE_VERTICES,
     )?;
     let index_buffer = create_buffer_with_data(
         &gpu,
         &transfer_buffer,
         &copy_pass,
-        BufferUsageFlags::Index,
+        BufferUsageFlags::INDEX,
         &CUBE_INDICES,
     )?;
 
@@ -211,7 +211,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_num_levels(1)
             .with_sample_count(SampleCount::NoMultiSampling)
             .with_format(TextureFormat::D16Unorm)
-            .with_usage(TextureUsage::Sampler | TextureUsage::DepthStencilTarget),
+            .with_usage(TextureUsage::SAMPLER | TextureUsage::DEPTH_STENCIL_TARGET),
     )?;
 
     let mut rotation = 45.0f32;
@@ -238,8 +238,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Again, like in gpu-clear.rs, we'd want to define basic operations for our cube
             let color_targets = [ColorTargetInfo::default()
                 .with_texture(&swapchain)
-                .with_load_op(LoadOp::Clear)
-                .with_store_op(StoreOp::Store)
+                .with_load_op(LoadOp::CLEAR)
+                .with_store_op(StoreOp::STORE)
                 .with_clear_color(Color::RGB(128, 128, 128))];
             // This time, however, we want depth testing, so we need to also target a depth texture buffer
             let depth_target = DepthStencilTargetInfo::new()
@@ -247,10 +247,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_cycle(true)
                 .with_clear_depth(1.0)
                 .with_clear_stencil(0)
-                .with_load_op(LoadOp::Clear)
-                .with_store_op(StoreOp::Store)
-                .with_stencil_load_op(LoadOp::Clear)
-                .with_stencil_store_op(StoreOp::Store);
+                .with_load_op(LoadOp::CLEAR)
+                .with_store_op(StoreOp::STORE)
+                .with_stencil_load_op(LoadOp::CLEAR)
+                .with_stencil_store_op(StoreOp::STORE);
             let render_pass =
                 gpu.begin_render_pass(&command_buffer, &color_targets, Some(&depth_target))?;
 
@@ -268,7 +268,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &BufferBinding::new()
                     .with_buffer(&index_buffer)
                     .with_offset(0),
-                IndexElementSize::_16Bit,
+                IndexElementSize::_16BIT,
             );
 
             // Set the rotation uniform for our cube vert shader

--- a/examples/gpu-texture.rs
+++ b/examples/gpu-texture.rs
@@ -194,7 +194,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| e.to_string())?;
 
     let gpu = sdl3::gpu::Device::new(
-        ShaderFormat::SpirV | ShaderFormat::Dxil | ShaderFormat::Dxbc | ShaderFormat::MetalLib,
+        ShaderFormat::SPIRV | ShaderFormat::DXIL | ShaderFormat::DXBC | ShaderFormat::METALLIB,
         true,
     )?
     .with_window(&window)?;
@@ -203,7 +203,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vert_shader = gpu
         .create_shader()
         .with_code(
-            ShaderFormat::SpirV,
+            ShaderFormat::SPIRV,
             include_bytes!("shaders/cube-texture.vert.spv"),
             ShaderStage::Vertex,
         )
@@ -213,7 +213,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let frag_shader = gpu
         .create_shader()
         .with_code(
-            ShaderFormat::SpirV,
+            ShaderFormat::SPIRV,
             include_bytes!("shaders/cube-texture.frag.spv"),
             ShaderStage::Fragment,
         )
@@ -284,7 +284,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let transfer_buffer = gpu
         .create_transfer_buffer()
         .with_size(vertices_len_bytes.max(indices_len_bytes) as u32)
-        .with_usage(TransferBufferUsage::Upload)
+        .with_usage(TransferBufferUsage::UPLOAD)
         .build()?;
 
     // We need to start a copy pass in order to transfer data to the GPU
@@ -296,14 +296,14 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         &gpu,
         &transfer_buffer,
         &copy_pass,
-        BufferUsageFlags::Vertex,
+        BufferUsageFlags::VERTEX,
         &CUBE_VERTICES,
     )?;
     let index_buffer = create_buffer_with_data(
         &gpu,
         &transfer_buffer,
         &copy_pass,
-        BufferUsageFlags::Index,
+        BufferUsageFlags::INDEX,
         &CUBE_INDICES,
     )?;
 
@@ -338,7 +338,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_num_levels(1)
             .with_sample_count(SampleCount::NoMultiSampling)
             .with_format(TextureFormat::D16Unorm)
-            .with_usage(TextureUsage::Sampler | TextureUsage::DepthStencilTarget),
+            .with_usage(TextureUsage::SAMPLER | TextureUsage::DEPTH_STENCIL_TARGET),
     )?;
 
     let mut rotation = 45.0f32;
@@ -365,8 +365,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Again, like in gpu-clear.rs, we'd want to define basic operations for our cube
             let color_targets = [ColorTargetInfo::default()
                 .with_texture(&swapchain)
-                .with_load_op(LoadOp::Clear)
-                .with_store_op(StoreOp::Store)
+                .with_load_op(LoadOp::CLEAR)
+                .with_store_op(StoreOp::STORE)
                 .with_clear_color(Color::RGB(128, 128, 128))];
             // This time, however, we want depth testing, so we need to also target a depth texture buffer
             let depth_target = DepthStencilTargetInfo::new()
@@ -374,10 +374,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .with_cycle(true)
                 .with_clear_depth(1.0)
                 .with_clear_stencil(0)
-                .with_load_op(LoadOp::Clear)
-                .with_store_op(StoreOp::Store)
-                .with_stencil_load_op(LoadOp::Clear)
-                .with_stencil_store_op(StoreOp::Store);
+                .with_load_op(LoadOp::CLEAR)
+                .with_store_op(StoreOp::STORE)
+                .with_stencil_load_op(LoadOp::CLEAR)
+                .with_stencil_store_op(StoreOp::STORE);
             let render_pass =
                 gpu.begin_render_pass(&command_buffer, &color_targets, Some(&depth_target))?;
 
@@ -395,7 +395,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &BufferBinding::new()
                     .with_buffer(&index_buffer)
                     .with_offset(0),
-                IndexElementSize::_16Bit,
+                IndexElementSize::_16BIT,
             );
             render_pass.bind_fragment_samplers(
                 0,
@@ -440,13 +440,13 @@ fn create_texture_from_image(
             .with_height(image_size.1)
             .with_layer_count_or_depth(1)
             .with_num_levels(1)
-            .with_usage(TextureUsage::Sampler),
+            .with_usage(TextureUsage::SAMPLER),
     )?;
 
     let transfer_buffer = gpu
         .create_transfer_buffer()
         .with_size(size_bytes)
-        .with_usage(TransferBufferUsage::Upload)
+        .with_usage(TransferBufferUsage::UPLOAD)
         .build()?;
 
     let mut buffer_mem = transfer_buffer.map::<u8>(gpu, false);

--- a/examples/gpu-triangle.rs
+++ b/examples/gpu-triangle.rs
@@ -25,7 +25,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // aren't using any shaders)
     // We'll also turn on debug mode to true, so we get debug stuff
     let gpu = Device::new(
-        ShaderFormat::SpirV | ShaderFormat::Dxil | ShaderFormat::Dxbc | ShaderFormat::MetalLib,
+        ShaderFormat::SPIRV | ShaderFormat::DXIL | ShaderFormat::DXBC | ShaderFormat::METALLIB,
         true,
     )?
     .with_window(&window)?;
@@ -36,13 +36,13 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Our shaders, require to be precompiled by a SPIR-V compiler beforehand
     let vs_shader = gpu
         .create_shader()
-        .with_code(ShaderFormat::SpirV, vs_source, ShaderStage::Vertex)
+        .with_code(ShaderFormat::SPIRV, vs_source, ShaderStage::Vertex)
         .with_entrypoint(c"main")
         .build()?;
 
     let fs_shader = gpu
         .create_shader()
-        .with_code(ShaderFormat::SpirV, fs_source, ShaderStage::Fragment)
+        .with_code(ShaderFormat::SPIRV, fs_source, ShaderStage::Fragment)
         .with_entrypoint(c"main")
         .build()?;
 
@@ -95,8 +95,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             let color_targets = [
                 ColorTargetInfo::default()
                     .with_texture(&swapchain)
-                    .with_load_op(LoadOp::Clear)
-                    .with_store_op(StoreOp::Store)
+                    .with_load_op(LoadOp::CLEAR)
+                    .with_store_op(StoreOp::STORE)
                     .with_clear_color(Color::RGB(5, 3, 255)), //blue with small RG bias
             ];
             let render_pass = gpu.begin_render_pass(&command_buffer, &color_targets, None)?;

--- a/src/sdl3/gpu/buffer.rs
+++ b/src/sdl3/gpu/buffer.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 use sys::gpu::{
     SDL_CreateGPUBuffer, SDL_CreateGPUTransferBuffer, SDL_GPUBuffer, SDL_GPUBufferBinding,
     SDL_GPUBufferCreateInfo, SDL_GPUBufferRegion, SDL_GPUTransferBuffer,
-    SDL_GPUTransferBufferCreateInfo, SDL_GPUTransferBufferLocation, SDL_GPUTransferBufferUsage,
-    SDL_GPUVertexBufferDescription, SDL_GPUVertexInputRate, SDL_MapGPUTransferBuffer,
-    SDL_ReleaseGPUBuffer, SDL_ReleaseGPUTransferBuffer, SDL_UnmapGPUTransferBuffer,
+    SDL_GPUTransferBufferCreateInfo, SDL_GPUTransferBufferLocation, SDL_GPUVertexBufferDescription,
+    SDL_GPUVertexInputRate, SDL_MapGPUTransferBuffer, SDL_ReleaseGPUBuffer,
+    SDL_ReleaseGPUTransferBuffer, SDL_UnmapGPUTransferBuffer,
 };
 
 #[repr(C)]
@@ -157,7 +157,7 @@ impl<'a> BufferBuilder<'a> {
     }
 
     pub fn with_usage(mut self, value: BufferUsageFlags) -> Self {
-        self.inner.usage = value as u32;
+        self.inner.usage = value.0;
         self
     }
 
@@ -267,7 +267,7 @@ impl<'a> TransferBufferBuilder<'a> {
 
     /// How the buffer will be used.
     pub fn with_usage(mut self, value: TransferBufferUsage) -> Self {
-        self.inner.usage = SDL_GPUTransferBufferUsage(value as i32);
+        self.inner.usage = value;
         self
     }
 

--- a/src/sdl3/gpu/device.rs
+++ b/src/sdl3/gpu/device.rs
@@ -55,7 +55,7 @@ impl Device {
 
     #[doc(alias = "SDL_CreateGPUDevice")]
     pub fn new(flags: ShaderFormat, debug_mode: bool) -> Result<Self, Error> {
-        let raw_device = unsafe { SDL_CreateGPUDevice(flags as u32, debug_mode, std::ptr::null()) };
+        let raw_device = unsafe { SDL_CreateGPUDevice(flags.0, debug_mode, std::ptr::null()) };
         if raw_device.is_null() {
             Err(get_error())
         } else {

--- a/src/sdl3/gpu/enums.rs
+++ b/src/sdl3/gpu/enums.rs
@@ -1,47 +1,26 @@
 use crate::sys;
 use std::ops::{BitAnd, BitOr};
-use sys::gpu::{
-    SDL_GPUBlendFactor, SDL_GPUBlendOp, SDL_GPU_COLORCOMPONENT_A, SDL_GPU_COLORCOMPONENT_B,
-    SDL_GPU_COLORCOMPONENT_G, SDL_GPU_COLORCOMPONENT_R,
-};
+use sys::gpu::{SDL_GPUBlendFactor, SDL_GPUBlendOp};
 
 macro_rules! impl_with {
     (bitwise_and_or $x:ident $prim:ident) => {
         impl BitOr<$x> for $x {
             type Output = $x;
             fn bitor(self, rhs: $x) -> Self::Output {
-                unsafe { std::mem::transmute((self as $prim) | (rhs as $prim)) }
+                $x(self.0 | rhs.0)
             }
         }
         impl BitAnd<$x> for $x {
             type Output = $x;
             fn bitand(self, rhs: $x) -> Self::Output {
-                unsafe { std::mem::transmute((self as $prim) & (rhs as $prim)) }
+                $x(self.0 & rhs.0)
             }
         }
     };
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum LoadOp {
-    #[default]
-    Load = sys::gpu::SDL_GPU_LOADOP_LOAD.0 as u32,
-    DontCare = sys::gpu::SDL_GPU_LOADOP_DONT_CARE.0 as u32,
-    Clear = sys::gpu::SDL_GPU_LOADOP_CLEAR.0 as u32,
-}
-impl_with!(bitwise_and_or LoadOp u32);
-
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum StoreOp {
-    #[default]
-    Store = sys::gpu::SDL_GPU_STOREOP_STORE.0 as u32,
-    DontCare = sys::gpu::SDL_GPU_STOREOP_DONT_CARE.0 as u32,
-    Resolve = sys::gpu::SDL_GPU_STOREOP_RESOLVE.0 as u32,
-    ResolveAndStore = sys::gpu::SDL_GPU_STOREOP_RESOLVE_AND_STORE.0 as u32,
-}
-impl_with!(bitwise_and_or StoreOp u32);
+pub type LoadOp = sys::gpu::SDL_GPULoadOp;
+pub type StoreOp = sys::gpu::SDL_GPUStoreOp;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -153,35 +132,35 @@ pub enum TextureFormat {
     Astc12x10Float = sys::gpu::SDL_GPU_TEXTUREFORMAT_ASTC_12x10_FLOAT.0 as u32,
     Astc12x12Float = sys::gpu::SDL_GPU_TEXTUREFORMAT_ASTC_12x12_FLOAT.0 as u32,
 }
-impl_with!(bitwise_and_or TextureFormat u32);
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum ShaderFormat {
-    #[default]
-    Invalid = sys::gpu::SDL_GPU_SHADERFORMAT_INVALID as u32,
-    Dxbc = sys::gpu::SDL_GPU_SHADERFORMAT_DXBC as u32,
-    Dxil = sys::gpu::SDL_GPU_SHADERFORMAT_DXIL as u32,
-    MetalLib = sys::gpu::SDL_GPU_SHADERFORMAT_METALLIB as u32,
-    Msl = sys::gpu::SDL_GPU_SHADERFORMAT_MSL as u32,
-    Private = sys::gpu::SDL_GPU_SHADERFORMAT_PRIVATE as u32,
-    SpirV = sys::gpu::SDL_GPU_SHADERFORMAT_SPIRV as u32,
+pub struct ShaderFormat(pub sys::gpu::SDL_GPUShaderFormat);
+impl ShaderFormat {
+    pub const INVALID: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_INVALID);
+    pub const DXBC: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_DXBC);
+    pub const DXIL: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_DXIL);
+    pub const METALLIB: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_METALLIB);
+    pub const MSL: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_MSL);
+    pub const PRIVATE: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_PRIVATE);
+    pub const SPIRV: Self = Self(sys::gpu::SDL_GPU_SHADERFORMAT_SPIRV);
 }
 impl_with!(bitwise_and_or ShaderFormat u32);
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum TextureUsage {
-    #[default]
-    Invalid = 0,
-    ComputeStorageWrite = sys::gpu::SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE,
-    ComputeStorageRead = sys::gpu::SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ,
-    ComputeSimultaneousReadWrite =
-        sys::gpu::SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE,
-    DepthStencilTarget = sys::gpu::SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET,
-    GraphicsStorageRead = sys::gpu::SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ,
-    Sampler = sys::gpu::SDL_GPU_TEXTUREUSAGE_SAMPLER,
-    ColorTarget = sys::gpu::SDL_GPU_TEXTUREUSAGE_COLOR_TARGET,
+pub struct TextureUsage(pub sys::gpu::SDL_GPUTextureUsageFlags);
+impl TextureUsage {
+    pub const INVALID: Self = Self(0);
+    pub const COMPUTE_STORAGE_WRITE: Self =
+        Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE);
+    pub const COMPUTE_STORAGE_READ: Self =
+        Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ);
+    pub const COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE: Self =
+        Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE);
+    pub const DEPTH_STENCIL_TARGET: Self =
+        Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET);
+    pub const GRAPHICS_STORAGE_READ: Self =
+        Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ);
+    pub const SAMPLER: Self = Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_SAMPLER);
+    pub const COLOR_TARGET: Self = Self(sys::gpu::SDL_GPU_TEXTUREUSAGE_COLOR_TARGET);
 }
 impl_with!(bitwise_and_or TextureUsage u32);
 
@@ -342,14 +321,7 @@ pub enum SamplerAddressMode {
     ClampToEdge = sys::gpu::SDL_GPUSamplerAddressMode::CLAMP_TO_EDGE.0 as u32,
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum IndexElementSize {
-    #[default]
-    _16Bit = sys::gpu::SDL_GPUIndexElementSize::_16BIT.0 as u32,
-    _32Bit = sys::gpu::SDL_GPUIndexElementSize::_32BIT.0 as u32,
-}
-impl_with!(bitwise_and_or IndexElementSize u32);
+pub type IndexElementSize = sys::gpu::SDL_GPUIndexElementSize;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -360,25 +332,19 @@ pub enum VertexInputRate {
 }
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum BufferUsageFlags {
-    #[default]
-    Vertex = sys::gpu::SDL_GPU_BUFFERUSAGE_VERTEX as u32,
-    Index = sys::gpu::SDL_GPU_BUFFERUSAGE_INDEX as u32,
-    Indirect = sys::gpu::SDL_GPU_BUFFERUSAGE_INDIRECT as u32,
-    GraphicsStorageRead = sys::gpu::SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ as u32,
-    ComputeStorageRead = sys::gpu::SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ as u32,
-    ComputeStorageWrite = sys::gpu::SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE as u32,
+pub struct BufferUsageFlags(pub sys::gpu::SDL_GPUBufferUsageFlags);
+impl BufferUsageFlags {
+    pub const VERTEX: Self = Self(sys::gpu::SDL_GPU_BUFFERUSAGE_VERTEX);
+    pub const INDEX: Self = Self(sys::gpu::SDL_GPU_BUFFERUSAGE_INDEX);
+    pub const INDIRECT: Self = Self(sys::gpu::SDL_GPU_BUFFERUSAGE_INDIRECT);
+    pub const GRAPHICS_STORAGE_READ: Self =
+        Self(sys::gpu::SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ);
+    pub const COMPUTE_STORAGE_READ: Self = Self(sys::gpu::SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ);
+    pub const COMPUTE_STORAGE_WRITE: Self =
+        Self(sys::gpu::SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE);
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum TransferBufferUsage {
-    #[default]
-    Upload = sys::gpu::SDL_GPUTransferBufferUsage::UPLOAD.0 as u32,
-    Download = sys::gpu::SDL_GPUTransferBufferUsage::DOWNLOAD.0 as u32,
-}
-impl_with!(bitwise_and_or TransferBufferUsage u32);
+pub type TransferBufferUsage = sys::gpu::SDL_GPUTransferBufferUsage;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -413,13 +379,13 @@ pub enum BlendOp {
 }
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u8)]
-pub enum ColorComponentFlags {
-    #[default]
-    RBit = SDL_GPU_COLORCOMPONENT_R,
-    GBit = SDL_GPU_COLORCOMPONENT_G,
-    BBit = SDL_GPU_COLORCOMPONENT_B,
-    ABit = SDL_GPU_COLORCOMPONENT_A,
+pub struct ColorComponentFlags(pub sys::gpu::SDL_GPUColorComponentFlags);
+
+impl ColorComponentFlags {
+    pub const R: Self = Self(sys::gpu::SDL_GPU_COLORCOMPONENT_R);
+    pub const G: Self = Self(sys::gpu::SDL_GPU_COLORCOMPONENT_G);
+    pub const B: Self = Self(sys::gpu::SDL_GPU_COLORCOMPONENT_B);
+    pub const A: Self = Self(sys::gpu::SDL_GPU_COLORCOMPONENT_A);
 }
 impl_with!(bitwise_and_or ColorComponentFlags u8);
 

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -11,10 +11,9 @@ use sys::gpu::{
     SDL_AcquireGPUSwapchainTexture, SDL_BindGPUFragmentSamplers, SDL_BindGPUIndexBuffer,
     SDL_BindGPUVertexBuffers, SDL_DrawGPUIndexedPrimitives, SDL_GPUBufferBinding,
     SDL_GPUColorTargetInfo, SDL_GPUCommandBuffer, SDL_GPUComputePass, SDL_GPUCopyPass,
-    SDL_GPUDepthStencilTargetInfo, SDL_GPUIndexElementSize, SDL_GPULoadOp, SDL_GPURenderPass,
-    SDL_GPUStoreOp, SDL_GPUTextureSamplerBinding, SDL_PushGPUComputeUniformData,
-    SDL_PushGPUFragmentUniformData, SDL_PushGPUVertexUniformData, SDL_UploadToGPUBuffer,
-    SDL_UploadToGPUTexture, SDL_WaitAndAcquireGPUSwapchainTexture,
+    SDL_GPUDepthStencilTargetInfo, SDL_GPURenderPass, SDL_GPUTextureSamplerBinding,
+    SDL_PushGPUComputeUniformData, SDL_PushGPUFragmentUniformData, SDL_PushGPUVertexUniformData,
+    SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture, SDL_WaitAndAcquireGPUSwapchainTexture,
 };
 
 use super::{Buffer, ComputePipeline};
@@ -154,24 +153,22 @@ impl DepthStencilTargetInfo {
     }
 
     pub fn with_load_op(mut self, value: LoadOp) -> Self {
-        self.inner.load_op = SDL_GPULoadOp(value as i32);
+        self.inner.load_op = value;
         self
     }
 
     pub fn with_store_op(mut self, value: StoreOp) -> Self {
-        self.inner.store_op = SDL_GPUStoreOp(value as i32);
+        self.inner.store_op = value;
         self
     }
 
     pub fn with_stencil_load_op(mut self, value: LoadOp) -> Self {
-        self.inner.stencil_load_op =
-            unsafe { std::mem::transmute::<_, sys::gpu::SDL_GPULoadOp>(value as u32) };
+        self.inner.stencil_load_op = value;
         self
     }
 
     pub fn with_stencil_store_op(mut self, value: StoreOp) -> Self {
-        self.inner.stencil_store_op =
-            unsafe { std::mem::transmute::<_, sys::gpu::SDL_GPUStoreOp>(value as u32) };
+        self.inner.stencil_store_op = value;
         self
     }
 
@@ -197,13 +194,11 @@ impl ColorTargetInfo {
         self
     }
     pub fn with_load_op(mut self, value: LoadOp) -> Self {
-        self.inner.load_op =
-            unsafe { std::mem::transmute::<_, sys::gpu::SDL_GPULoadOp>(value as u32) };
+        self.inner.load_op = value;
         self
     }
     pub fn with_store_op(mut self, value: StoreOp) -> Self {
-        self.inner.store_op =
-            unsafe { std::mem::transmute::<_, sys::gpu::SDL_GPUStoreOp>(value as u32) };
+        self.inner.store_op = value;
         self
     }
     pub fn with_clear_color(mut self, value: Color) -> Self {
@@ -269,13 +264,7 @@ impl RenderPass {
 
     #[doc(alias = "SDL_BindGPUIndexBuffer")]
     pub fn bind_index_buffer(&self, binding: &BufferBinding, index_element_size: IndexElementSize) {
-        unsafe {
-            SDL_BindGPUIndexBuffer(
-                self.raw(),
-                &binding.inner,
-                SDL_GPUIndexElementSize(index_element_size as i32),
-            )
-        }
+        unsafe { SDL_BindGPUIndexBuffer(self.raw(), &binding.inner, index_element_size) }
     }
 
     #[doc(alias = "SDL_BindGPUFragmentSamplers")]

--- a/src/sdl3/gpu/pipeline.rs
+++ b/src/sdl3/gpu/pipeline.rs
@@ -256,7 +256,7 @@ impl ColorTargetBlendState {
 
     /// A bitmask specifying which of the RGBA components are enabled for writing. Writes to all channels if enable_color_write_mask is false.
     pub fn with_color_write_mask(mut self, flags: ColorComponentFlags) -> Self {
-        self.inner.color_write_mask = flags as u8;
+        self.inner.color_write_mask = flags.0;
         self
     }
 
@@ -463,7 +463,7 @@ impl<'a> ComputePipelineBuilder<'a> {
     }
 
     pub fn with_code(mut self, fmt: ShaderFormat, code: &'a [u8]) -> Self {
-        self.inner.format = fmt as u32;
+        self.inner.format = fmt.0;
         self.inner.code = code.as_ptr();
         self.inner.code_size = code.len();
         self

--- a/src/sdl3/gpu/shader.rs
+++ b/src/sdl3/gpu/shader.rs
@@ -63,7 +63,7 @@ impl<'a> ShaderBuilder<'a> {
     }
 
     pub fn with_code(mut self, fmt: ShaderFormat, code: &'a [u8], stage: ShaderStage) -> Self {
-        self.inner.format = fmt as u32;
+        self.inner.format = fmt.0;
         self.inner.code = code.as_ptr();
         self.inner.code_size = code.len() as usize;
         self.inner.stage = unsafe { std::mem::transmute(stage as u32) };

--- a/src/sdl3/gpu/texture.rs
+++ b/src/sdl3/gpu/texture.rs
@@ -361,7 +361,7 @@ impl TextureCreateInfo {
 
     /// How the texture is intended to be used by the client.
     pub fn with_usage(mut self, value: TextureUsage) -> Self {
-        self.inner.usage = value as u32;
+        self.inner.usage = value.0;
         self
     }
 


### PR DESCRIPTION
Hi, I don't know the state of [sdl3::gpu refactor #158](https://github.com/vhspace/sdl3-rs/pull/158), but I think we can divide the refactoring into several PRs.

This one concerns the correction of enumerations ([Unsound types in gpu::enums #147](https://github.com/vhspace/sdl3-rs/issues/147)).

This allows to do OR operator like:
```rust
TextureUsage::SAMPLER | TextureUsage::DEPTH_STENCIL_TARGET
```
  