### PR TITLE
Allow to bind samplers for compute pass

### DIFF
--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -434,6 +434,18 @@ impl ComputePass {
         }
     }
 
+    #[doc(alias = "SDL_BindGPUComputeSamplers")]
+    pub fn bind_compute_samplers(&self, first_slot: u32, bindings: &[TextureSamplerBinding]) {
+        unsafe {
+            sys::gpu::SDL_BindGPUComputeSamplers(
+                self.inner,
+                first_slot,
+                bindings.as_ptr() as *const SDL_GPUTextureSamplerBinding,
+                bindings.len() as u32,
+            );
+        }
+    }
+
     #[doc(alias = "SDL_DispatchGPUCompute")]
     pub fn dispatch(&self, groupcount_x: u32, groupcount_y: u32, groupcount_z: u32) {
         unsafe {

--- a/src/sdl3/gpu/pipeline.rs
+++ b/src/sdl3/gpu/pipeline.rs
@@ -499,6 +499,11 @@ impl<'a> ComputePipelineBuilder<'a> {
         self
     }
 
+    pub fn with_samplers(mut self, value: u32) -> Self {
+        self.inner.num_samplers = value;
+        self
+    }
+
     pub fn with_thread_count(mut self, x: u32, y: u32, z: u32) -> Self {
         self.inner.threadcount_x = x;
         self.inner.threadcount_y = y;


### PR DESCRIPTION
Hi, another PR to add `with_samplers` method when building a compute pipeline, and `bind_compute_samplers` during a compute pass