### PR TITLE
Added IOStream::from_vec.

### DIFF
--- a/tests/iostream.rs
+++ b/tests/iostream.rs
@@ -1,0 +1,14 @@
+extern crate sdl3;
+use std::io::Read;
+
+#[test]
+fn iostream_from_vec() {
+    let logo = std::fs::read("./assets/SDL_logo.bmp").unwrap();
+
+    let mut ios = sdl3::iostream::IOStream::from_vec(logo.clone()).unwrap();
+
+    let mut output = Vec::new();
+    ios.read_to_end(&mut output).unwrap();
+
+    assert_eq!(output, logo);
+}


### PR DESCRIPTION
Added `IOStream::from_vec` which takes ownership of the vector, allowing `IOStream` to have a lifetime of `'static` like `IOStream::from_file`.

Needed to add a field to the struct to contain the data. Also added a test. This solves #214 .