### PR TITLE
feat: add fence and blit operations

### DIFF
--- a/src/sdl3/gpu/device.rs
+++ b/src/sdl3/gpu/device.rs
@@ -19,6 +19,7 @@ use sys::gpu::{
 };
 
 use super::{
+    pass::Fence,
     pipeline::{StorageBufferReadWriteBinding, StorageTextureReadWriteBinding},
     ComputePass, ComputePipelineBuilder,
 };
@@ -221,6 +222,23 @@ impl Device {
 
     pub fn create_compute_pipeline<'a>(&'a self) -> ComputePipelineBuilder<'a> {
         ComputePipelineBuilder::new(self)
+    }
+
+    #[doc(alias = "SDL_WaitForGPUFences")]
+    pub fn wait_fences(&self, wait_all: bool, fences: &[Fence]) -> Result<(), Error> {
+        let fences: Vec<_> = fences.iter().map(|x| x.raw()).collect();
+        unsafe {
+            if !sys::gpu::SDL_WaitForGPUFences(
+                self.raw(),
+                wait_all,
+                fences.as_ptr(),
+                fences.len() as u32,
+            ) {
+                Err(get_error())
+            } else {
+                Ok(())
+            }
+        }
     }
 
     #[doc(alias = "SDL_GetGPUShaderFormats")]

--- a/src/sdl3/gpu/mod.rs
+++ b/src/sdl3/gpu/mod.rs
@@ -20,7 +20,8 @@ pub use enums::{
 
 mod pass;
 pub use pass::{
-    ColorTargetInfo, CommandBuffer, ComputePass, CopyPass, DepthStencilTargetInfo, RenderPass,
+    BlitInfo, ColorTargetInfo, CommandBuffer, ComputePass, CopyPass, DepthStencilTargetInfo,
+    RenderPass,
 };
 
 mod pipeline;

--- a/src/sdl3/gpu/mod.rs
+++ b/src/sdl3/gpu/mod.rs
@@ -20,7 +20,7 @@ pub use enums::{
 
 mod pass;
 pub use pass::{
-    BlitInfo, ColorTargetInfo, CommandBuffer, ComputePass, CopyPass, DepthStencilTargetInfo,
+    BlitInfo, ColorTargetInfo, CommandBuffer, ComputePass, CopyPass, DepthStencilTargetInfo, Fence,
     RenderPass,
 };
 

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -9,14 +9,15 @@ use crate::{
 };
 use sys::gpu::{
     SDL_AcquireGPUSwapchainTexture, SDL_BindGPUFragmentSamplers, SDL_BindGPUIndexBuffer,
-    SDL_BindGPUVertexBuffers, SDL_DrawGPUIndexedPrimitives, SDL_GPUBufferBinding,
+    SDL_BindGPUVertexBuffers, SDL_DrawGPUIndexedPrimitives, SDL_GPUBlitInfo, SDL_GPUBufferBinding,
     SDL_GPUColorTargetInfo, SDL_GPUCommandBuffer, SDL_GPUComputePass, SDL_GPUCopyPass,
-    SDL_GPUDepthStencilTargetInfo, SDL_GPURenderPass, SDL_GPUTextureSamplerBinding,
-    SDL_PushGPUComputeUniformData, SDL_PushGPUFragmentUniformData, SDL_PushGPUVertexUniformData,
-    SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture, SDL_WaitAndAcquireGPUSwapchainTexture,
+    SDL_GPUDepthStencilTargetInfo, SDL_GPUFilter, SDL_GPULoadOp, SDL_GPURenderPass,
+    SDL_GPUTextureSamplerBinding, SDL_PushGPUComputeUniformData, SDL_PushGPUFragmentUniformData,
+    SDL_PushGPUVertexUniformData, SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture,
+    SDL_WaitAndAcquireGPUSwapchainTexture,
 };
 
-use super::{Buffer, ComputePipeline};
+use super::{Buffer, ComputePipeline, Filter};
 
 pub struct CommandBuffer {
     pub(super) inner: *mut SDL_GPUCommandBuffer,
@@ -115,6 +116,13 @@ impl CommandBuffer {
         }
     }
 
+    #[doc(alias = "SDL_BlitGPUTexture")]
+    pub fn blit_texture(&self, blit_info: BlitInfo) {
+        unsafe {
+            sys::gpu::SDL_BlitGPUTexture(self.inner, &blit_info.inner);
+        }
+    }
+
     #[doc(alias = "SDL_SubmitGPUCommandBuffer")]
     pub fn submit(self) -> Result<(), Error> {
         if unsafe { sys::gpu::SDL_SubmitGPUCommandBuffer(self.inner) } {
@@ -206,6 +214,88 @@ impl ColorTargetInfo {
         self.inner.clear_color.g = (value.g as f32) / 255.0;
         self.inner.clear_color.b = (value.b as f32) / 255.0;
         self.inner.clear_color.a = (value.a as f32) / 255.0;
+        self
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct BlitInfo {
+    inner: SDL_GPUBlitInfo,
+}
+impl BlitInfo {
+    pub fn with_source_texture(mut self, texture: &Texture) -> Self {
+        self.inner.source.texture = texture.raw();
+        self
+    }
+
+    pub fn with_source_mip(mut self, mip_level: u32) -> Self {
+        self.inner.source.mip_level = mip_level;
+        self
+    }
+
+    pub fn with_source_region(
+        mut self,
+        layer_or_depth: u32,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        self.inner.source.layer_or_depth_plane = layer_or_depth;
+        self.inner.source.x = x;
+        self.inner.source.y = y;
+        self.inner.source.w = width;
+        self.inner.source.h = height;
+        self
+    }
+
+    pub fn with_destination_texture(mut self, texture: &Texture) -> Self {
+        self.inner.destination.texture = texture.raw();
+        self
+    }
+
+    pub fn with_destination_mip(mut self, mip_level: u32) -> Self {
+        self.inner.destination.mip_level = mip_level;
+        self
+    }
+
+    pub fn with_destination_region(
+        mut self,
+        layer_or_depth: u32,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        self.inner.destination.layer_or_depth_plane = layer_or_depth;
+        self.inner.destination.x = x;
+        self.inner.destination.y = y;
+        self.inner.destination.w = width;
+        self.inner.destination.h = height;
+        self
+    }
+
+    pub fn with_load_op(mut self, load_op: LoadOp) -> Self {
+        self.inner.load_op = SDL_GPULoadOp(i32::from(load_op));
+        self
+    }
+
+    pub fn with_clear_color(mut self, clear_color: Color) -> Self {
+        self.inner.clear_color.r = (clear_color.r as f32) / 255.0;
+        self.inner.clear_color.g = (clear_color.g as f32) / 255.0;
+        self.inner.clear_color.b = (clear_color.b as f32) / 255.0;
+        self.inner.clear_color.a = (clear_color.a as f32) / 255.0;
+        self
+    }
+
+    pub fn with_filter(mut self, filter: Filter) -> Self {
+        self.inner.filter = SDL_GPUFilter(filter as i32);
+        self
+    }
+
+    pub fn with_cycle(mut self, cycle: bool) -> Self {
+        self.inner.cycle = cycle;
         self
     }
 }

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -1,3 +1,4 @@
+use super::{Buffer, ComputePipeline, Device, Filter, WeakDevice};
 use crate::{
     get_error,
     gpu::{
@@ -7,17 +8,53 @@ use crate::{
     pixels::Color,
     Error,
 };
+use std::sync::Arc;
 use sys::gpu::{
     SDL_AcquireGPUSwapchainTexture, SDL_BindGPUFragmentSamplers, SDL_BindGPUIndexBuffer,
     SDL_BindGPUVertexBuffers, SDL_DrawGPUIndexedPrimitives, SDL_GPUBlitInfo, SDL_GPUBufferBinding,
     SDL_GPUColorTargetInfo, SDL_GPUCommandBuffer, SDL_GPUComputePass, SDL_GPUCopyPass,
-    SDL_GPUDepthStencilTargetInfo, SDL_GPUFilter, SDL_GPULoadOp, SDL_GPURenderPass,
+    SDL_GPUDepthStencilTargetInfo, SDL_GPUFence, SDL_GPUFilter, SDL_GPULoadOp, SDL_GPURenderPass,
     SDL_GPUTextureSamplerBinding, SDL_PushGPUComputeUniformData, SDL_PushGPUFragmentUniformData,
-    SDL_PushGPUVertexUniformData, SDL_UploadToGPUBuffer, SDL_UploadToGPUTexture,
-    SDL_WaitAndAcquireGPUSwapchainTexture,
+    SDL_PushGPUVertexUniformData, SDL_QueryGPUFence, SDL_ReleaseGPUFence, SDL_UploadToGPUBuffer,
+    SDL_UploadToGPUTexture, SDL_WaitAndAcquireGPUSwapchainTexture,
 };
 
-use super::{Buffer, ComputePipeline, Filter};
+/// Manages the raw `SDL_GPUFence` pointer and releases it on drop
+struct FenceContainer {
+    raw: *mut SDL_GPUFence,
+    device: WeakDevice,
+}
+impl Drop for FenceContainer {
+    fn drop(&mut self) {
+        if let Some(device) = self.device.upgrade() {
+            unsafe { SDL_ReleaseGPUFence(device.raw(), self.raw) }
+        }
+    }
+}
+
+pub struct Fence {
+    inner: Arc<FenceContainer>,
+}
+impl Fence {
+    pub(super) fn new(device: &Device, raw_fence: *mut SDL_GPUFence) -> Self {
+        Self {
+            inner: Arc::new(FenceContainer {
+                raw: raw_fence,
+                device: device.weak(),
+            }),
+        }
+    }
+
+    #[inline]
+    pub fn raw(&self) -> *mut SDL_GPUFence {
+        self.inner.raw
+    }
+
+    #[doc(alias = "SDL_QueryGPUFence")]
+    pub fn query(&self, device: &Device) -> bool {
+        unsafe { SDL_QueryGPUFence(device.raw(), self.inner.raw) }
+    }
+}
 
 pub struct CommandBuffer {
     pub(super) inner: *mut SDL_GPUCommandBuffer,
@@ -129,6 +166,16 @@ impl CommandBuffer {
             Ok(())
         } else {
             Err(get_error())
+        }
+    }
+
+    #[doc(alias = "SDL_SubmitGPUCommandBufferAndAcquireFence")]
+    pub fn submit_and_acquire_fence(self, device: &Device) -> Result<Fence, Error> {
+        let fence_raw = unsafe { sys::gpu::SDL_SubmitGPUCommandBufferAndAcquireFence(self.inner) };
+        if fence_raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Fence::new(device, fence_raw))
         }
     }
 


### PR DESCRIPTION
This PR introduces GPU fence and blit operations to the SDL3 GPU module.

This PR:
- Add `Fence` struct to manage `SDL_GPUFence`,
- Add `Device::wait_fences` for waiting on one or more fences (`SDL_WaitForGPUFences`),
- Add `Fence::query` for checking fence state (`SDL_QueryGPUFence`),
- Add `CommandBuffer::submit_and_acquire_fence` for submitting commands and acquiring a fence (`SDL_SubmitGPUCommandBufferAndAcquireFence`),
- Add `BlitInfo` struct to wrap `SDL_GPUBlitInfo`,
- Add `CommandBuffer::blit_texture` for performing GPU blit operations (`SDL_BlitGPUTexture`).