### PR TITLE
feat(gpu): add Viewport wrapper and RenderPass::set_scissor

### DIFF
--- a/src/sdl3/gpu/device.rs
+++ b/src/sdl3/gpu/device.rs
@@ -24,6 +24,30 @@ use super::{
     ComputePass, ComputePipelineBuilder,
 };
 
+pub struct Viewport {
+    inner: SDL_GPUViewport,
+}
+impl Viewport {
+    #[doc(alias = "SDL_GPUViewport")]
+    pub fn new(x: f32, y: f32, w: f32, h: f32, min_depth: f32, max_depth: f32) -> Self {
+        Self {
+            inner: SDL_GPUViewport {
+                x,
+                y,
+                w,
+                h,
+                min_depth,
+                max_depth,
+            },
+        }
+    }
+
+    #[inline]
+    pub fn raw(&self) -> *const SDL_GPUViewport {
+        &self.inner
+    }
+}
+
 /// Manages the raw `SDL_GPUDevice` pointer and releases it on drop
 pub(super) struct DeviceContainer(*mut SDL_GPUDevice);
 impl DeviceContainer {
@@ -129,8 +153,8 @@ impl Device {
     }
 
     #[doc(alias = "SDL_SetGPUViewport")]
-    pub fn set_viewport(&self, render_pass: &RenderPass, viewport: SDL_GPUViewport) {
-        unsafe { SDL_SetGPUViewport(render_pass.inner, &viewport) }
+    pub fn set_viewport(&self, render_pass: &RenderPass, viewport: Viewport) {
+        unsafe { SDL_SetGPUViewport(render_pass.inner, viewport.raw()) }
     }
 
     pub fn get_swapchain_texture_format(&self, w: &crate::video::Window) -> TextureFormat {

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -6,6 +6,7 @@ use crate::{
         TextureRegion, TextureSamplerBinding, TextureTransferInfo, TransferBufferLocation,
     },
     pixels::Color,
+    rect::Rect,
     Error,
 };
 use std::sync::Arc;
@@ -480,6 +481,11 @@ impl RenderPass {
                 first_instance as u32,
             );
         }
+    }
+
+    #[doc(alias = "SDL_SetGPUScissor")]
+    pub fn set_scissor(&self, scissor: Rect) {
+        unsafe { sys::gpu::SDL_SetGPUScissor(self.inner, scissor.raw()) }
     }
 }
 


### PR DESCRIPTION
Hi :wave: 

New PR:
- Added a new `Viewport` wrapper around `SDL_GPUViewport`,
- Updated `Device::set_viewport` to take a `Viewport` instead of a raw `SDL_GPUViewport`,
- Added `RenderPass::set_scissor(scissor: Rect)` to wrap `SDL_SetGPUScissor`,
