### PR TITLE
fix: expose viewport wrapper publicly

### DIFF
--- a/src/sdl3/gpu/mod.rs
+++ b/src/sdl3/gpu/mod.rs
@@ -7,7 +7,7 @@ pub use buffer::{
 };
 
 mod device;
-pub use device::Device;
+pub use device::{Device, Viewport};
 
 mod enums;
 pub use enums::{


### PR DESCRIPTION
#220 helpfully introduced a wrapper around SDL_GPUViewport, however it wasn't exposed publicly, preventing crate users from constructing it.

This is a tiny fix that corrects that.