### PR TITLE
ci: remove build cache

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -88,10 +88,10 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache cargo output
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: stable-all-features
+      # - name: Cache cargo output
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     key: stable-all-features
 
       - name: Fetch dependencies
         run: cargo +stable fetch --locked

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -88,10 +88,10 @@ jobs:
         with:
           toolchain: stable
 
-      # - name: Cache cargo output
-      #   uses: Swatinem/rust-cache@v2
-      #   with:
-      #     key: stable-all-features
+      - name: Cache cargo output
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: stable-${{ matrix.os }}-${{ matrix.feature }}
 
       - name: Fetch dependencies
         run: cargo +stable fetch --locked


### PR DESCRIPTION
This MR remove the caching of rust output for the build step, for each feature and os.

This seems to fix errors on master.