### PR TITLE
ci: add lint pr title workflow

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,0 +1,62 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            gfx
+            gpu
+            hint
+            image
+            keyboard
+            mixer
+            mouse
+            ttf
+            audio
+            clipboard
+            cpuinfo
+            dialog
+            event
+            filesystem
+            gamepad
+            guid
+            haptic
+            iostream
+            joystick
+            log
+            macros
+            messagebox
+            pen
+            pixels
+            properties
+            raw_window_handle
+            rect
+            render
+            sensor
+            surface
+            timer
+            touch
+            url
+            util
+            version
+            video
+          requireScope: false
+          # If the PR only contains a single commit, the action will validate that
+          # it matches the configured pattern.
+          validateSingleCommit: true
+          # Related to `validateSingleCommit` you can opt-in to validate that the PR
+          # title matches a single commit to avoid confusion.
+          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
This MR add a step that lint PR title, to enforce [Conventional Commits](https://www.conventionalcommits.org/) spec.

This can be use to automated releases and changelog, (because this will produce a clean git history), but this required to configure the GitHub repository to [use the squash & merge strategy](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests), with the option "Default to PR title for squash merge commits".

More details on https://github.com/amannn/action-semantic-pull-request.

---

This can be a first step toward creating a change log and managing breaking changes.

With this PR, PRs with breaking change can be manually flagged with a `!` in the title. But in the future, this could be done with a tool that checks the crate public API (or assert if it's not done).

