### PR TITLE
feat: Added EventSubsystem::set_event_enabled and EventSubsystem::event_enable

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -266,6 +266,16 @@ impl crate::EventSubsystem {
     ) -> EventWatch<'a, CB> {
         EventWatch::add(callback)
     }
+
+    #[doc(alias = "SDL_SetEventEnabled")]
+    pub fn set_event_enabled(event_type: EventType, enabled: bool) {
+        unsafe { sys::events::SDL_SetEventEnabled(event_type.into(), enabled) };
+    }
+
+    #[doc(alias = "SDL_EventEnabled")]
+    pub fn event_enabled(event_type: EventType) -> bool {
+        unsafe { sys::events::SDL_EventEnabled(event_type.into()) }
+    }
 }
 
 /// Types of events that can be delivered.


### PR DESCRIPTION
Was trying to port some code and found that neither `SDL_EventEnabled` nor `SDL_SetEventEnabled` are exposed.

EDIT: Force pushed because I forgot to run `cargo-fmt`.

EDIT2: I didn't add `SDL_FilterEvents` because it's a bit more work and I don't use it.