### PR TITLE
ci: remove rust cache

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Cache cargo output
         uses: Swatinem/rust-cache@v2
-        with:
-          key: stable-${{ matrix.feature }}
 
       - name: Fetch dependencies
         run: cargo +stable fetch --locked
@@ -90,8 +88,6 @@ jobs:
 
       - name: Cache cargo output
         uses: Swatinem/rust-cache@v2
-        with:
-          key: stable-${{ matrix.os }}-${{ matrix.feature }}
 
       - name: Fetch dependencies
         run: cargo +stable fetch --locked

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,9 +39,6 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Cache cargo output
-        uses: Swatinem/rust-cache@v2
-
       - name: Fetch dependencies
         run: cargo +stable fetch --locked
 
@@ -85,9 +82,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-
-      - name: Cache cargo output
-        uses: Swatinem/rust-cache@v2
 
       - name: Fetch dependencies
         run: cargo +stable fetch --locked


### PR DESCRIPTION
Hi, dependabot PRs seems to failed again on the same error

```
  Error: Os { code: 17, kind: AlreadyExists, message: "File exists" }
```

So to avoid any cache issue, I remove caching steps :sweat_smile: 