### PR TITLE
feat: make draw_rect consistent with fill_rect generic parameter

### DIFF
--- a/examples/renderer/a05_rectangles.rs
+++ b/examples/renderer/a05_rectangles.rs
@@ -56,9 +56,7 @@ impl AppState {
         rects[0].w = 100.0 + (100.0 * scale);
         rects[0].h = 100.0 + (100.0 * scale);
         self.canvas.set_draw_color(Color::RGB(255, 0, 0));
-        self.canvas
-            .draw_rect(rects[0])
-            .unwrap();
+        self.canvas.draw_rect(rects[0]).unwrap();
 
         // Draw several rectangles
         for i in 0..3 {
@@ -70,9 +68,7 @@ impl AppState {
         }
         self.canvas.set_draw_color(Color::RGB(0, 255, 0));
         for rect in &rects[..3] {
-            self.canvas
-                .draw_rect(*rect)
-                .unwrap();
+            self.canvas.draw_rect(*rect).unwrap();
         }
 
         // Draw a filled rectangle

--- a/examples/renderer/a05_rectangles.rs
+++ b/examples/renderer/a05_rectangles.rs
@@ -57,7 +57,7 @@ impl AppState {
         rects[0].h = 100.0 + (100.0 * scale);
         self.canvas.set_draw_color(Color::RGB(255, 0, 0));
         self.canvas
-            .draw_rect(Self::convert_frect_to_rect(&rects[0]).into())
+            .draw_rect(rects[0])
             .unwrap();
 
         // Draw several rectangles
@@ -71,7 +71,7 @@ impl AppState {
         self.canvas.set_draw_color(Color::RGB(0, 255, 0));
         for rect in &rects[..3] {
             self.canvas
-                .draw_rect(Self::convert_frect_to_rect(rect).into())
+                .draw_rect(*rect)
                 .unwrap();
         }
 

--- a/src/sdl3/render.rs
+++ b/src/sdl3/render.rs
@@ -1431,8 +1431,8 @@ impl<T: RenderTarget> Canvas<T> {
     /// Draws a rectangle on the current rendering target.
     /// Errors if drawing fails for any reason (e.g. driver failure)
     #[doc(alias = "SDL_RenderRect")]
-    pub fn draw_rect(&mut self, rect: FRect) -> Result<(), Error> {
-        let rect = rect.to_ll();
+    pub fn draw_rect<R: Into<FRect>>(&mut self, rect: R) -> Result<(), Error> {
+        let rect = rect.into().to_ll();
 
         let result = unsafe { sys::render::SDL_RenderRect(self.context.raw, &rect) };
         if !result {


### PR DESCRIPTION
Hey! I was experimenting with the library and noticed `draw_rect` and `fill_rect` handle parameters differently. There could be a good reason for this, but just in case there
  isn't, here's a small patch to make them consistent.

Updated `Canvas::draw_rect` to accept `R: Into<FRect>` like `fill_rect` does