### PR TITLE
fix(event): add Send + Sync bounds for EventWatch to avoid soundness hole

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -3138,7 +3138,7 @@ pub struct EventWatch<'a, CB: EventWatchCallback + 'a> {
     _phantom: PhantomData<&'a CB>,
 }
 
-impl<'a, CB: EventWatchCallback + 'a + Send + Sync> EventWatch<'a, CB> {
+impl<'a, CB: EventWatchCallback + 'a> EventWatch<'a, CB> {
     fn add(callback: CB) -> EventWatch<'a, CB> {
         let f = Box::new(callback);
         let mut watch = EventWatch {

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -260,7 +260,7 @@ impl crate::EventSubsystem {
     ///     dbg!(event);
     /// });
     /// ```
-    pub fn add_event_watch<'a, CB: EventWatchCallback + 'a>(
+    pub fn add_event_watch<'a, CB: EventWatchCallback + 'a + Send + Sync>(
         &self,
         callback: CB,
     ) -> EventWatch<'a, CB> {
@@ -3132,13 +3132,13 @@ pub trait EventWatchCallback {
 /// An handler for the event watch callback.
 /// One must bind this struct in a variable as long as you want to keep the callback active.
 /// For further information, see [`EventSubsystem::add_event_watch`].
-pub struct EventWatch<'a, CB: EventWatchCallback + 'a> {
+pub struct EventWatch<'a, CB: EventWatchCallback + 'a + Send + Sync> {
     activated: bool,
     callback: Box<CB>,
     _phantom: PhantomData<&'a CB>,
 }
 
-impl<'a, CB: EventWatchCallback + 'a> EventWatch<'a, CB> {
+impl<'a, CB: EventWatchCallback + 'a + Send + Sync> EventWatch<'a, CB> {
     fn add(callback: CB) -> EventWatch<'a, CB> {
         let f = Box::new(callback);
         let mut watch = EventWatch {
@@ -3191,7 +3191,7 @@ impl<'a, CB: EventWatchCallback + 'a> EventWatch<'a, CB> {
     }
 }
 
-impl<'a, CB: EventWatchCallback + 'a> Drop for EventWatch<'a, CB> {
+impl<'a, CB: EventWatchCallback + 'a + Send + Sync> Drop for EventWatch<'a, CB> {
     fn drop(&mut self) {
         self.deactivate();
     }


### PR DESCRIPTION
## Motivation
According to [the SDL3 documention for SDL_AddEventWatch](https://wiki.libsdl.org/SDL3/SDL_AddEventWatch):
> WARNING: Be very careful of what you do in the event filter function, as it may run in a different thread!

The existing API does not reflect this, and so it's possible to trigger UB (example should work on any platform, since [SDL_PushEvent ultimately calls event watch callbacks](https://github.com/libsdl-org/SDL/blob/release-3.2.x/src/events/SDL_events.c#L1721)  and can be called from any thread):
<details>
<summary>Example</summary>

```rs
let sdl = sdl3::init().unwrap();
let events = sdl.event().unwrap();
// Cell is !Sync but Send
let cell = std::cell::Cell::new(0);
let not_sync = events.add_event_watch(|_| {
    // could happen in a different thread
    cell.set(0);
});
// MutexGuard is !Send but Sync
let mutex = std::sync::Mutex::new(0);
let mut guard = Some(mutex.lock().unwrap()); 
let not_send = events.add_event_watch(move |_| {
    // this releases the lock the first time the event callback is called, which if it happens
    // on another thread, can trigger undefined behavior
    drop(guard.take());
});
std::thread::scope(|s| {
    s.spawn(|| {
        loop {
            // this should force the callbacks to be called in a separate thread
            events
                .push_event(sdl3::event::Event::Unknown { 
                    timestamp: 0, 
                    type_: u32::MAX 
                })
                .unwrap();
        }
    });
    loop {
        // will happen in a different thread from the Cell::set() call in the 
        // not_sync callback, which would be conflicting non-atomic accesses
        cell.set(1);
        
        // don't need to do anything with the mutex, dropping a guard in another thread is we need
    }
});
```
</details>
I believe that both Send and Sync are necessary, although I'd be happy to be shown that looser bounds would still work.

## Changes
- add `Send + Sync` bound to `EventWatchCallback`
- add `Send + Sync` bound to blanket impl for `EventWatchCallback` on `FnMut(Event)` types

This is a breaking change, since it's adding trait bounds that weren't there before, but it's also a soundness bug.