### PR TITLE
feat: Add primary selection API

### DIFF
--- a/src/sdl3/clipboard.rs
+++ b/src/sdl3/clipboard.rs
@@ -63,4 +63,39 @@ impl ClipboardUtil {
     pub fn has_clipboard_text(&self) -> bool {
         unsafe { sys::clipboard::SDL_HasClipboardText() }
     }
+
+    #[doc(alias = "SDL_SetPrimarySelectionText")]
+    pub fn set_primary_selection_text(&self, text: &str) -> Result<(), Error> {
+        unsafe {
+            let text = CString::new(text).unwrap();
+            let result =
+                sys::clipboard::SDL_SetPrimarySelectionText(text.as_ptr() as *const c_char);
+
+            if !result {
+                Err(get_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[doc(alias = "SDL_GetPrimarySelectionText")]
+    pub fn primary_selection_text(&self) -> Result<String, Error> {
+        unsafe {
+            let buf = sys::clipboard::SDL_GetPrimarySelectionText();
+
+            if buf.is_null() {
+                Err(get_error())
+            } else {
+                let s = CStr::from_ptr(buf as *const _).to_str().unwrap().to_owned();
+                sys::stdinc::SDL_free(buf as *mut c_void);
+                Ok(s)
+            }
+        }
+    }
+
+    #[doc(alias = "SDL_HasPrimarySelectionText")]
+    pub fn has_primary_selection_text(&self) -> bool {
+        unsafe { sys::clipboard::SDL_HasPrimarySelectionText() }
+    }
 }


### PR DESCRIPTION
This commit add the primary clipboard support.
It is the sdl3 version of this commit in the rust-sdl2 crate:
https://github.com/Rust-SDL2/rust-sdl2/commit/a995dfe6a8a2a8e4f643d5d44ba5cb5ae4d2c78b

