### PR TITLE
fix(event): correct previous attempt to fix EventWatch soundness hole

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -260,10 +260,7 @@ impl crate::EventSubsystem {
     ///     dbg!(event);
     /// });
     /// ```
-    pub fn add_event_watch<CB: EventWatchCallback>(
-        &self,
-        callback: CB,
-    ) -> EventWatch<CB> {
+    pub fn add_event_watch<CB: EventWatchCallback>(&self, callback: CB) -> EventWatch<CB> {
         EventWatch::add(callback)
     }
 

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -260,10 +260,10 @@ impl crate::EventSubsystem {
     ///     dbg!(event);
     /// });
     /// ```
-    pub fn add_event_watch<'a, CB: EventWatchCallback + 'a>(
+    pub fn add_event_watch<CB: EventWatchCallback>(
         &self,
         callback: CB,
-    ) -> EventWatch<'a, CB> {
+    ) -> EventWatch<CB> {
         EventWatch::add(callback)
     }
 
@@ -3125,26 +3125,24 @@ impl EventSender {
 }
 
 /// A callback trait for [`EventSubsystem::add_event_watch`].
-pub trait EventWatchCallback: Send + Sync {
+pub trait EventWatchCallback: Send + 'static {
     fn callback(&mut self, event: Event);
 }
 
 /// An handler for the event watch callback.
 /// One must bind this struct in a variable as long as you want to keep the callback active.
 /// For further information, see [`EventSubsystem::add_event_watch`].
-pub struct EventWatch<'a, CB: EventWatchCallback + 'a> {
+pub struct EventWatch<CB: EventWatchCallback> {
     activated: bool,
     callback: Box<CB>,
-    _phantom: PhantomData<&'a CB>,
 }
 
-impl<'a, CB: EventWatchCallback + 'a> EventWatch<'a, CB> {
-    fn add(callback: CB) -> EventWatch<'a, CB> {
+impl<CB: EventWatchCallback> EventWatch<CB> {
+    fn add(callback: CB) -> EventWatch<CB> {
         let f = Box::new(callback);
         let mut watch = EventWatch {
             activated: false,
             callback: f,
-            _phantom: PhantomData,
         };
         watch.activate();
         watch
@@ -3191,7 +3189,7 @@ impl<'a, CB: EventWatchCallback + 'a> EventWatch<'a, CB> {
     }
 }
 
-impl<'a, CB: EventWatchCallback + 'a> Drop for EventWatch<'a, CB> {
+impl<CB: EventWatchCallback> Drop for EventWatch<CB> {
     fn drop(&mut self) {
         self.deactivate();
     }
@@ -3207,7 +3205,7 @@ extern "C" fn event_callback_marshall<CB: EventWatchCallback>(
     false
 }
 
-impl<F: FnMut(Event) + Send + Sync> EventWatchCallback for F {
+impl<F: FnMut(Event) + Send + 'static> EventWatchCallback for F {
     fn callback(&mut self, event: Event) {
         self(event)
     }


### PR DESCRIPTION
After making #256 to try to fix the soundness hole with `EventWatch`, I opened a similar PR on the rust-sdl2 repo (Rust-SDL2/rust-sdl2#1509), which had the same issue with `EventWatch`. The feedback and discussion on that PR made me realize the original fix was wrong, so this is the correction to that fix. This is the same set of corrections that were applied to the rust-sdl2 repo, minus a tweak to fix a similar issue with `AudioCallback` in the sdl2 crate because that issue apparently already got fixed in the sdl3 crate. 

## Changes
- Change `EventWatchCallback` trait bounds to `Send + 'static` instead of `Send + Sync` 
  - Reason: SDL never actually accesses or provides access to the callback immutably from multiple threads at once, so `Sync` isn't necessary, and `'static` is necessary because calling `mem::forget` on the `EventWatch` is perfectly safe and could cause the callback to continue running even after it outlives data it references. `Send` is still necessary because the callback may be called from a different thread than it starts in.
- Remove lifetime parameter from `EventWatch` 
  - Reason: it's unnecessary when the callback is `'static`, since `EventWatch` no longer borrows any non-`'static` data