### PR TITLE
fix: don't unwrap keycode and pass directly the Option.

### DIFF
--- a/src/sdl3/keyboard/keycode.rs
+++ b/src/sdl3/keyboard/keycode.rs
@@ -572,7 +572,7 @@ impl Keycode {
                 Ok(name) => match sys::keyboard::SDL_GetKeyFromName(name.as_ptr() as *const c_char)
                 {
                     UNKNOWN => None,
-                    keycode_id => Some(Keycode::from_i32(keycode_id as i32).unwrap()),
+                    keycode_id => Keycode::from_i32(keycode_id as i32),
                 },
                 // string contains a nul byte - it won't match anything.
                 Err(_) => None,


### PR DESCRIPTION
Having some users hitting the unwrap there, which shouldn't exist because it's basically doing `Some(Option<Keycode>.unwrap())`.