### PR TITLE
feat: added SDL_SetWindowHitTest wrapper

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -770,7 +770,6 @@ impl HitTestResult {
     }
 }
 
-
 /// Represents the "shell" of a `Window`.
 ///
 /// You can set get and set many of the `SDL_Window` properties (i.e., border, size, `PixelFormat`, etc)
@@ -2330,32 +2329,34 @@ impl Window {
         } else {
             Err(get_error())
         }
-    } 
-    
+    }
+
     /// Sets a hit test function for the window.
     #[doc(alias = "SDL_SetWindowHitTest")]
     pub fn set_hit_test(
         &mut self,
-        hit_test: impl Fn (crate::rect::Point) -> HitTestResult,
+        hit_test: impl Fn(crate::rect::Point) -> HitTestResult,
     ) -> Result<(), Error> {
         // Box the closure to extend its lifetime and convert it to a raw pointer.
-        let boxed: Box<Box<dyn Fn(crate::rect::Point) -> HitTestResult>> = Box::new(Box::new(hit_test));
+        let boxed: Box<Box<dyn Fn(crate::rect::Point) -> HitTestResult>> =
+            Box::new(Box::new(hit_test));
         let userdata = Box::into_raw(boxed) as *mut c_void;
 
         unsafe extern "C" fn hit_test_sys(
             _: *mut sys::video::SDL_Window,
             point: *const sys::rect::SDL_Point,
-            data: *mut c_void
+            data: *mut c_void,
         ) -> sys::video::SDL_HitTestResult {
             // Reborrow the boxed closure.
-            let callback =data as *mut Box<dyn Fn(crate::rect::Point) -> HitTestResult>;
+            let callback = data as *mut Box<dyn Fn(crate::rect::Point) -> HitTestResult>;
             let point = crate::rect::Point::from_ll(*point);
 
             (*callback)(point).to_ll()
-        }        
+        }
 
         unsafe {
-            let result = sys::video::SDL_SetWindowHitTest(self.context.raw, Some(hit_test_sys), userdata);
+            let result =
+                sys::video::SDL_SetWindowHitTest(self.context.raw, Some(hit_test_sys), userdata);
             if result {
                 Ok(())
             } else {
@@ -2364,8 +2365,6 @@ impl Window {
         }
     }
 }
-
-
 
 #[derive(Copy, Clone)]
 #[doc(alias = "SDL_GetVideoDriver")]

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -721,7 +721,7 @@ impl FlashOperation {
     }
 }
 
-// Represents the result of a hit test.
+/// Represents the result of a hit test.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[repr(i32)]
 pub enum HitTestResult {
@@ -2335,7 +2335,7 @@ impl Window {
     #[doc(alias = "SDL_SetWindowHitTest")]
     pub fn set_hit_test(
         &mut self,
-        hit_test: impl Fn(crate::rect::Point) -> HitTestResult,
+        hit_test: impl (Fn(crate::rect::Point) -> HitTestResult) + 'static,
     ) -> Result<(), Error> {
         // Box the closure to extend its lifetime and convert it to a raw pointer.
         let boxed: Box<Box<dyn Fn(crate::rect::Point) -> HitTestResult>> =


### PR DESCRIPTION
This PR adds a wrapper function and required enums for the `SDL_SetWindowHitTest` function in the `video` submodule. 

The function is currently implemented with a trampoline function to wrap around bindgen's `extern  "C"` function pointer type.

To replace `SDL_SetWindowHitTest(SDL_Window* win, const SDL_Point* area, void* data)`'s `data` void pointer, I've implemented the closure as an `impl Fn` to be able to capture variables as needed into the closure instead of passing them as function parameters.

> This is my first time PR'ing to this repo so this might be a bad implementation/API, please give me feedback, thank you so much!