### PR TITLE
feat: Derive Default for Color

### DIFF
--- a/src/sdl3/pixels.rs
+++ b/src/sdl3/pixels.rs
@@ -120,7 +120,7 @@ fn pixel_format_details_basic() {
     assert_eq!(det.bytes_per_pixel, 3);
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Color {
     pub r: u8,
     pub g: u8,


### PR DESCRIPTION
I don't see a reason not to derive from it it and many reasons to do so. Like easily when deriving default for structs with a color inside.