### PR TITLE
feat(filesystem): expose SDL_GetCurrentDirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ target/
 .idea/
 .vscode/
 .aider*
+AGENTS.override.md


### PR DESCRIPTION
Implements a safe wrapper for SDL_GetCurrentDirectory that returns a PathBuf and frees SDL-allocated memory. Also ignores AGENTS.override.md so the local maintainer notes file stays out of version control.

Testing
- cargo check -p sdl3 --features build-from-source