### PR TITLE
feat(audio): expose SDL3 audio stream controls

### DIFF
--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -51,6 +51,7 @@
 //! std::thread::sleep(Duration::from_millis(2000));
 //! ```
 
+use crate::clear_error;
 use crate::get_error;
 use crate::iostream::IOStream;
 use crate::sys;
@@ -66,6 +67,8 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::path::Path;
+use std::ptr;
+use std::slice;
 use sys::audio::{SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, SDL_AUDIO_DEVICE_DEFAULT_RECORDING};
 use sys::stdinc::SDL_free;
 
@@ -382,17 +385,17 @@ impl AudioFormat {
     /// Signed 16-bit samples, native endian
     #[inline]
     pub const fn s16_sys() -> AudioFormat {
-        AudioFormat::S16MSB
+        AudioFormat::S16BE
     }
     /// Signed 32-bit samples, native endian
     #[inline]
     pub const fn s32_sys() -> AudioFormat {
-        AudioFormat::S32MSB
+        AudioFormat::S32BE
     }
     /// 32-bit floating point samples, native endian
     #[inline]
     pub const fn f32_sys() -> AudioFormat {
-        AudioFormat::F32MSB
+        AudioFormat::F32BE
     }
 }
 
@@ -802,11 +805,15 @@ impl AudioDevice {
     pub fn bind_streams(&self, streams: &[&AudioStream]) -> Result<(), Error> {
         let streams_ptrs: Vec<*mut sys::audio::SDL_AudioStream> =
             streams.iter().map(|s| s.stream).collect();
+        let stream_count: c_int = streams
+            .len()
+            .try_into()
+            .map_err(|_| Error("Too many audio streams to bind".to_owned()))?;
         let result = unsafe {
             sys::audio::SDL_BindAudioStreams(
                 self.device_id.id(),
                 streams_ptrs.as_ptr() as *mut _,
-                streams.len() as i32,
+                stream_count,
             )
         };
         if result {
@@ -1122,6 +1129,36 @@ impl AudioStream {
         self.device_id().and_then(|id| id.name().ok())
     }
 
+    /// Unbind this stream from the device it is attached to, if any.
+    #[doc(alias = "SDL_UnbindAudioStream")]
+    pub fn unbind_from_device(&self) {
+        unsafe {
+            sys::audio::SDL_UnbindAudioStream(self.stream);
+        }
+    }
+
+    /// Unbind multiple audio streams at once.
+    #[doc(alias = "SDL_UnbindAudioStreams")]
+    pub fn unbind_streams(streams: &[&AudioStream]) -> Result<(), Error> {
+        if streams.is_empty() {
+            return Ok(());
+        }
+
+        let count: c_int = streams
+            .len()
+            .try_into()
+            .map_err(|_| Error("Too many audio streams to unbind".to_owned()))?;
+
+        let ptrs: Vec<*mut sys::audio::SDL_AudioStream> =
+            streams.iter().map(|stream| stream.stream).collect();
+
+        unsafe {
+            sys::audio::SDL_UnbindAudioStreams(ptrs.as_ptr(), count);
+        }
+
+        Ok(())
+    }
+
     /// Retrieves the source and destination formats of the audio stream.
     ///
     /// Returns a tuple `(src_spec, dst_spec)` where each is an `Option<AudioSpec>`.
@@ -1144,6 +1181,29 @@ impl AudioStream {
                 None
             };
             Ok((src_spec, dst_spec))
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Change the input and/or output format used by the stream.
+    #[doc(alias = "SDL_SetAudioStreamFormat")]
+    pub fn set_format(
+        &self,
+        src_spec: Option<&AudioSpec>,
+        dst_spec: Option<&AudioSpec>,
+    ) -> Result<(), Error> {
+        let src = src_spec.map(|spec| sys::audio::SDL_AudioSpec::from(spec));
+        let dst = dst_spec.map(|spec| sys::audio::SDL_AudioSpec::from(spec));
+        let result = unsafe {
+            sys::audio::SDL_SetAudioStreamFormat(
+                self.stream,
+                src.as_ref().map_or(ptr::null(), |spec| spec as *const _),
+                dst.as_ref().map_or(ptr::null(), |spec| spec as *const _),
+            )
+        };
+        if result {
+            Ok(())
         } else {
             Err(get_error())
         }
@@ -1173,8 +1233,141 @@ impl AudioStream {
         }
     }
 
+    /// Query the current frequency ratio applied to the stream.
+    #[doc(alias = "SDL_GetAudioStreamFrequencyRatio")]
+    pub fn frequency_ratio(&self) -> Result<f32, Error> {
+        unsafe {
+            clear_error();
+            let ratio = sys::audio::SDL_GetAudioStreamFrequencyRatio(self.stream);
+            if ratio == 0.0 {
+                let err = get_error();
+                if err.is_empty() {
+                    return Ok(0.0);
+                }
+                Err(err)
+            } else {
+                Ok(ratio)
+            }
+        }
+    }
+
+    /// Change the frequency ratio applied to the stream.
+    #[doc(alias = "SDL_SetAudioStreamFrequencyRatio")]
+    pub fn set_frequency_ratio(&self, ratio: f32) -> Result<(), Error> {
+        let result = unsafe { sys::audio::SDL_SetAudioStreamFrequencyRatio(self.stream, ratio) };
+        if result {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Retrieve the current input channel map.
+    #[doc(alias = "SDL_GetAudioStreamInputChannelMap")]
+    pub fn input_channel_map(&self) -> Result<Option<Vec<i32>>, Error> {
+        unsafe {
+            clear_error();
+            let mut count: c_int = 0;
+            let map_ptr = sys::audio::SDL_GetAudioStreamInputChannelMap(self.stream, &mut count);
+            if map_ptr.is_null() {
+                let err = get_error();
+                if err.is_empty() {
+                    return Ok(None);
+                }
+                return Err(err);
+            }
+
+            if count < 0 {
+                SDL_free(map_ptr as *mut c_void);
+                return Err(Error(
+                    "SDL reported a negative input channel count".to_owned(),
+                ));
+            }
+
+            let entries = slice::from_raw_parts(map_ptr as *const c_int, count as usize).to_vec();
+            SDL_free(map_ptr as *mut c_void);
+            Ok(Some(entries))
+        }
+    }
+
+    /// Retrieve the current output channel map.
+    #[doc(alias = "SDL_GetAudioStreamOutputChannelMap")]
+    pub fn output_channel_map(&self) -> Result<Option<Vec<i32>>, Error> {
+        unsafe {
+            clear_error();
+            let mut count: c_int = 0;
+            let map_ptr = sys::audio::SDL_GetAudioStreamOutputChannelMap(self.stream, &mut count);
+            if map_ptr.is_null() {
+                let err = get_error();
+                if err.is_empty() {
+                    return Ok(None);
+                }
+                return Err(err);
+            }
+
+            if count < 0 {
+                SDL_free(map_ptr as *mut c_void);
+                return Err(Error(
+                    "SDL reported a negative output channel count".to_owned(),
+                ));
+            }
+
+            let entries = slice::from_raw_parts(map_ptr as *const c_int, count as usize).to_vec();
+            SDL_free(map_ptr as *mut c_void);
+            Ok(Some(entries))
+        }
+    }
+
+    /// Configure the input channel map for this stream. Pass `None` to reset.
+    #[doc(alias = "SDL_SetAudioStreamInputChannelMap")]
+    pub fn set_input_channel_map(&self, map: Option<&[i32]>) -> Result<(), Error> {
+        let (ptr, count) = match map {
+            Some(values) => {
+                let count: c_int = values
+                    .len()
+                    .try_into()
+                    .map_err(|_| Error("Channel map exceeds SDL limits".to_owned()))?;
+                (values.as_ptr(), count)
+            }
+            None => (ptr::null(), 0),
+        };
+
+        let result =
+            unsafe { sys::audio::SDL_SetAudioStreamInputChannelMap(self.stream, ptr, count) };
+
+        if result {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Configure the output channel map for this stream. Pass `None` to reset.
+    #[doc(alias = "SDL_SetAudioStreamOutputChannelMap")]
+    pub fn set_output_channel_map(&self, map: Option<&[i32]>) -> Result<(), Error> {
+        let (ptr, count) = match map {
+            Some(values) => {
+                let count: c_int = values
+                    .len()
+                    .try_into()
+                    .map_err(|_| Error("Channel map exceeds SDL limits".to_owned()))?;
+                (values.as_ptr(), count)
+            }
+            None => (ptr::null(), 0),
+        };
+
+        let result =
+            unsafe { sys::audio::SDL_SetAudioStreamOutputChannelMap(self.stream, ptr, count) };
+
+        if result {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
     /// Pauses playback of the audio stream.
-    #[doc(alias = "SDL_PauseAudioStream")]
+    #[doc(alias = "SDL_PauseAudioStreamDevice")]
     pub fn pause(&self) -> Result<(), Error> {
         let result = unsafe { sys::audio::SDL_PauseAudioStreamDevice(self.stream) };
         if result {
@@ -1185,7 +1378,7 @@ impl AudioStream {
     }
 
     /// Resumes playback of the audio stream.
-    #[doc(alias = "SDL_ResumeAudioStream")]
+    #[doc(alias = "SDL_ResumeAudioStreamDevice")]
     pub fn resume(&self) -> Result<(), Error> {
         let result = unsafe { sys::audio::SDL_ResumeAudioStreamDevice(self.stream) };
         if result {


### PR DESCRIPTION
Adds safe wrappers for the remaining SDL3 audio stream APIs, including unbind, format changes, frequency ratio, and channel maps, plus the big-endian helper fix and safer bind_streams conversion.

Testing
- cargo check -p sdl3 --features build-from-source