### PR TITLE
feat(audio): add AudioStream::device_paused

### DIFF
--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -1388,6 +1388,24 @@ impl AudioStream {
         }
     }
 
+    /// Check whether the device bound to this stream is paused.
+    #[doc(alias = "SDL_AudioStreamDevicePaused")]
+    pub fn device_paused(&self) -> Result<bool, Error> {
+        unsafe {
+            clear_error();
+            if sys::audio::SDL_AudioStreamDevicePaused(self.stream) {
+                Ok(true)
+            } else {
+                let err = get_error();
+                if err.is_empty() {
+                    Ok(false)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
     /// Gets the number of converted/resampled bytes available.
     #[doc(alias = "SDL_GetAudioStreamAvailable")]
     pub fn available_bytes(&self) -> Result<i32, Error> {


### PR DESCRIPTION
Adds AudioStream::device_paused so callers can query SDL_AudioStreamDevicePaused without dipping into sys.

Testing
- cargo check -p sdl3 --features build-from-source