### PR TITLE
docs(video): fix metal_view docs

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1532,9 +1532,9 @@ impl WindowBuilder {
         self
     }
 
-    /// Create a SDL_MetalView when constructing the window.
-    /// This is required when using the raw_window_handle feature on macOS.
-    /// Has no effect no other platforms.
+    /// Create an `SDL_MetalView` when constructing the window.
+    /// This is required when using the `raw-window-handle` feature on macOS.
+    /// Has no effect on other platforms.
     pub fn metal_view(&mut self) -> &mut WindowBuilder {
         self.create_metal_view = true;
         self


### PR DESCRIPTION
## Summary
Fixes the typo in WindowBuilder::metal_view docs ("Has no effect no other platforms" -> "Has no effect on other platforms") and clarifies the SDL_MetalView wording.

