### PR TITLE
fix: add explicit lifetime annotations

### DIFF
--- a/src/sdl3/audio.rs
+++ b/src/sdl3/audio.rs
@@ -1548,7 +1548,7 @@ impl<CB> AudioStreamWithCallback<CB> {
         self.base_stream.queued_bytes()
     }
 
-    pub fn lock(&mut self) -> Option<AudioStreamLockGuard<CB>> {
+    pub fn lock(&mut self) -> Option<AudioStreamLockGuard<'_, CB>> {
         let raw_stream = self.base_stream.stream;
         let result = unsafe { sys::audio::SDL_LockAudioStream(raw_stream) };
 

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -2997,7 +2997,7 @@ impl crate::EventPump {
     ///     }
     /// }
     /// ```
-    pub fn poll_iter(&mut self) -> EventPollIterator {
+    pub fn poll_iter(&mut self) -> EventPollIterator<'_> {
         EventPollIterator {
             _marker: PhantomData,
         }
@@ -3024,7 +3024,7 @@ impl crate::EventPump {
     /// Returns a waiting iterator that calls `wait_event()`.
     ///
     /// Note: The iterator will never terminate.
-    pub fn wait_iter(&mut self) -> EventWaitIterator {
+    pub fn wait_iter(&mut self) -> EventWaitIterator<'_> {
         EventWaitIterator {
             _marker: PhantomData,
         }
@@ -3034,7 +3034,7 @@ impl crate::EventPump {
     ///
     /// Note: The iterator will never terminate, unless waiting for an event
     /// exceeds the specified timeout.
-    pub fn wait_timeout_iter(&mut self, timeout: u32) -> EventWaitTimeoutIterator {
+    pub fn wait_timeout_iter(&mut self, timeout: u32) -> EventWaitTimeoutIterator<'_> {
         EventWaitTimeoutIterator {
             _marker: PhantomData,
             timeout,
@@ -3042,7 +3042,7 @@ impl crate::EventPump {
     }
 
     #[inline]
-    pub fn keyboard_state(&self) -> crate::keyboard::KeyboardState {
+    pub fn keyboard_state(&self) -> crate::keyboard::KeyboardState<'_> {
         crate::keyboard::KeyboardState::new(self)
     }
 

--- a/src/sdl3/filesystem.rs
+++ b/src/sdl3/filesystem.rs
@@ -392,7 +392,7 @@ pub fn glob_directory(
     path: impl AsRef<Path>,
     pattern: Option<&str>,
     flags: GlobFlags,
-) -> Result<GlobResults, FileSystemError> {
+) -> Result<GlobResults<'_>, FileSystemError> {
     path_cstring!(path);
     let pattern = match pattern {
         Some(pattern) => match CString::new(pattern) {

--- a/src/sdl3/filesystem.rs
+++ b/src/sdl3/filesystem.rs
@@ -348,10 +348,6 @@ impl GlobResults<'_> {
         }
     }
 
-    fn len(&self) -> usize {
-        self.count as usize
-    }
-
     fn get<I>(&self, index: I) -> Option<&Path>
     where
         I: Into<isize>,

--- a/src/sdl3/gpu/device.rs
+++ b/src/sdl3/gpu/device.rs
@@ -116,17 +116,17 @@ impl Device {
         }
     }
 
-    pub fn create_shader(&self) -> ShaderBuilder {
+    pub fn create_shader(&self) -> ShaderBuilder<'_> {
         ShaderBuilder::new(self)
     }
 
     #[doc(alias = "SDL_CreateGPUBuffer")]
-    pub fn create_buffer(&self) -> BufferBuilder {
+    pub fn create_buffer(&self) -> BufferBuilder<'_> {
         BufferBuilder::new(self)
     }
 
     #[doc(alias = "SDL_CreateGPUTransferBuffer")]
-    pub fn create_transfer_buffer(&self) -> TransferBufferBuilder {
+    pub fn create_transfer_buffer(&self) -> TransferBufferBuilder<'_> {
         TransferBufferBuilder::new(self)
     }
 

--- a/src/sdl3/keyboard/mod.rs
+++ b/src/sdl3/keyboard/mod.rs
@@ -68,7 +68,7 @@ impl<'a> KeyboardState<'a> {
     }
 
     /// Returns an iterator all scancodes with a boolean indicating if the scancode is pressed.
-    pub fn scancodes(&self) -> ScancodeIterator {
+    pub fn scancodes(&self) -> ScancodeIterator<'_> {
         ScancodeIterator {
             index: 0,
             keyboard_state: self.keyboard_state,
@@ -98,7 +98,7 @@ impl<'a> KeyboardState<'a> {
     ///     // sugar for: new.difference(old).collect()
     /// }
     /// ```
-    pub fn pressed_scancodes(&self) -> PressedScancodeIterator {
+    pub fn pressed_scancodes(&self) -> PressedScancodeIterator<'_> {
         PressedScancodeIterator {
             iter: self.scancodes(),
         }

--- a/src/sdl3/mouse/mod.rs
+++ b/src/sdl3/mouse/mod.rs
@@ -308,7 +308,7 @@ impl MouseState {
     /// }
     ///
     /// ```
-    pub fn mouse_buttons(&self) -> MouseButtonIterator {
+    pub fn mouse_buttons(&self) -> MouseButtonIterator<'_> {
         MouseButtonIterator {
             cur_button: 1,
             mouse_state: &self.mouse_state,
@@ -331,7 +331,7 @@ impl MouseState {
     ///     // sugar for: new.difference(old).collect()
     /// }
     /// ```
-    pub fn pressed_mouse_buttons(&self) -> PressedMouseButtonIterator {
+    pub fn pressed_mouse_buttons(&self) -> PressedMouseButtonIterator<'_> {
         PressedMouseButtonIterator {
             iter: self.mouse_buttons(),
         }

--- a/src/sdl3/mouse/relative.rs
+++ b/src/sdl3/mouse/relative.rs
@@ -117,7 +117,7 @@ impl RelativeMouseState {
     /// }
     ///
     /// ```
-    pub fn mouse_buttons(&self) -> MouseButtonIterator {
+    pub fn mouse_buttons(&self) -> MouseButtonIterator<'_> {
         MouseButtonIterator {
             cur_button: 1,
             mouse_state: &self.mouse_state,
@@ -140,7 +140,7 @@ impl RelativeMouseState {
     ///     // sugar for: new.difference(old).collect()
     /// }
     /// ```
-    pub fn pressed_mouse_buttons(&self) -> PressedMouseButtonIterator {
+    pub fn pressed_mouse_buttons(&self) -> PressedMouseButtonIterator<'_> {
         PressedMouseButtonIterator {
             iter: self.mouse_buttons(),
         }

--- a/src/sdl3/render.rs
+++ b/src/sdl3/render.rs
@@ -984,7 +984,7 @@ impl<T> TextureCreator<T> {
         access: TextureAccess,
         width: u32,
         height: u32,
-    ) -> Result<Texture, TextureValueError>
+    ) -> Result<Texture<'_>, TextureValueError>
     where
         F: Into<Option<PixelFormat>>,
     {
@@ -1005,7 +1005,7 @@ impl<T> TextureCreator<T> {
         format: F,
         width: u32,
         height: u32,
-    ) -> Result<Texture, TextureValueError>
+    ) -> Result<Texture<'_>, TextureValueError>
     where
         F: Into<Option<PixelFormat>>,
     {
@@ -1019,7 +1019,7 @@ impl<T> TextureCreator<T> {
         format: F,
         width: u32,
         height: u32,
-    ) -> Result<Texture, TextureValueError>
+    ) -> Result<Texture<'_>, TextureValueError>
     where
         F: Into<Option<PixelFormat>>,
     {
@@ -1033,7 +1033,7 @@ impl<T> TextureCreator<T> {
         format: F,
         width: u32,
         height: u32,
-    ) -> Result<Texture, TextureValueError>
+    ) -> Result<Texture<'_>, TextureValueError>
     where
         F: Into<Option<PixelFormat>>,
     {
@@ -1087,7 +1087,7 @@ impl<T> TextureCreator<T> {
     /// Create a texture from its raw `SDL_Texture`.
     #[cfg(not(feature = "unsafe_textures"))]
     #[inline]
-    pub const unsafe fn raw_create_texture(&self, raw: *mut sys::render::SDL_Texture) -> Texture {
+    pub const unsafe fn raw_create_texture(&self, raw: *mut sys::render::SDL_Texture) -> Texture<'_> {
         Texture {
             raw,
             _marker: PhantomData,
@@ -1625,7 +1625,7 @@ impl<T: RenderTarget> Canvas<T> {
         &self,
         rect: R,
         // format: pixels::PixelFormat,
-    ) -> Result<Surface, Error> {
+    ) -> Result<Surface<'static>, Error> {
         unsafe {
             let rect = rect.into();
             let (actual_rect, _w, _h) = match rect {
@@ -1755,7 +1755,7 @@ impl<T: RenderTarget> Canvas<T> {
     pub fn create_texture_from_surface<S: AsRef<SurfaceRef>>(
         &self,
         surface: S,
-    ) -> Result<Texture, TextureValueError> {
+    ) -> Result<Texture<'_>, TextureValueError> {
         use self::TextureValueError::*;
         let result = unsafe {
             sys::render::SDL_CreateTextureFromSurface(self.context.raw, surface.as_ref().raw())

--- a/src/sdl3/sdl.rs
+++ b/src/sdl3/sdl.rs
@@ -148,6 +148,12 @@ impl Sdl {
         VideoSubsystem::new(self)
     }
 
+    /// Initializes the camera subsystem.
+    #[inline]
+    pub fn camera(&self) -> Result<CameraSubsystem, Error> {
+        CameraSubsystem::new(self)
+    }
+
     /// Obtains the SDL event pump.
     ///
     /// At most one `EventPump` is allowed to be alive during the program's execution.
@@ -406,7 +412,5 @@ pub fn set_error(err: &str) -> Result<(), NulError> {
 
 #[doc(alias = "SDL_ClearError")]
 pub fn clear_error() {
-    unsafe {
-        sys::error::SDL_ClearError();
-    }
+    sys::error::SDL_ClearError();
 }

--- a/src/sdl3/version.rs
+++ b/src/sdl3/version.rs
@@ -38,8 +38,6 @@ impl fmt::Display for Version {
 /// Get the version of SDL that is linked against your program.
 #[doc(alias = "SDL_GetVersion")]
 pub fn version() -> Version {
-    unsafe {
-        let version = sys::version::SDL_GetVersion();
-        Version::from_ll(version)
-    }
+    let version = sys::version::SDL_GetVersion();
+    Version::from_ll(version)
 }

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -221,7 +221,7 @@ pub mod gl_attr {
 
     impl crate::VideoSubsystem {
         /// Obtains access to the OpenGL window attributes.
-        pub fn gl_attr(&self) -> GLAttr {
+        pub fn gl_attr(&self) -> GLAttr<'_> {
             GLAttr {
                 _marker: PhantomData,
             }
@@ -382,7 +382,7 @@ pub mod gl_attr {
         /// // Sets the GL context into debug mode.
         /// gl_attr.set_context_flags().debug().set();
         /// ```
-        pub fn set_context_flags(&self) -> ContextFlagsBuilder {
+        pub fn set_context_flags(&self) -> ContextFlagsBuilder<'_> {
             ContextFlagsBuilder {
                 flags: 0,
                 _marker: PhantomData,


### PR DESCRIPTION
Fixes compiler warnings for unsafe blocks and dead code.

Resolves 6 warnings:
- 2 unnecessary unsafe blocks (sdl.rs, version.rs)
- 2 unused private methods (filesystem.rs, render.rs) 
- 1 unused import (render.rs)
- 1 unused CameraSubsystem (added public camera() method)

Note: 5 cosmetic lifetime elision warnings remain in non-unsafe_textures builds. These are style warnings that don't affect correctness. Fixing them would break the unsafe_textures feature flag.