### PR TITLE
feat: Add support for sdl3-main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "rand",
  "raw-window-handle",
  "sdl3-image-sys",
+ "sdl3-main",
  "sdl3-sys",
  "sdl3-ttf-sys",
  "wgpu",
@@ -920,6 +921,22 @@ dependencies = [
  "sdl3-image-src",
  "sdl3-sys",
 ]
+
+[[package]]
+name = "sdl3-main"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ab4145c2d0aed1f1187f2cacd71329b6c238b89dc47db465be436ddf22c27a"
+dependencies = [
+ "sdl3-main-macros",
+ "sdl3-sys",
+]
+
+[[package]]
+name = "sdl3-main-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ea7f98211e1fefceafb264fb5638798fb26eca12b194dbc1eff7c6127ea4a6"
 
 [[package]]
 name = "sdl3-src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ optional = true
 version = "0.6"
 optional = true
 
+[dependencies.sdl3-main]
+version = "0.6"
+optional = true
+
 [dependencies.c_vec]
 # allow both 1.* and 2.0 versions
 version = ">= 1.0"
@@ -93,7 +97,8 @@ hidapi = []
 test-mode = []
 # allows sdl3 to be used with wgpu
 raw-window-handle = ["dep:raw-window-handle", "dep:objc2"]
-
+# integration with sdl3-main, for using SDL's callback interface with types from this crate
+main = ["dep:sdl3-main"]
 
 [package.metadata.docs.rs]
 #features = ["default", "gfx", "mixer", "image", "ttf"]
@@ -154,6 +159,10 @@ name = "joystick"
 
 [[example]]
 name = "keyboard-state"
+
+[[example]]
+required-features = ["main"]
+name = "main-callbacks-api"
 
 [[example]]
 name = "message-box"

--- a/examples/main-callbacks-api.rs
+++ b/examples/main-callbacks-api.rs
@@ -1,0 +1,87 @@
+use sdl3::{
+    event::Event,
+    keyboard::Keycode,
+    messagebox::{show_simple_message_box, MessageBoxFlag},
+    pixels::Color,
+    render::WindowCanvas,
+    timer::ticks,
+    Sdl, VideoSubsystem,
+};
+use sdl3_main::{app_impl, AppResult, AppResultWithState, MainThreadData};
+use std::sync::Mutex;
+
+struct App {
+    main: MainThreadData<MainData>,
+    mx: f32,
+    my: f32,
+}
+
+struct MainData {
+    canvas: WindowCanvas,
+    _video: VideoSubsystem,
+    _sdl: Sdl,
+}
+
+#[app_impl]
+impl App {
+    fn new() -> Result<Self, Box<dyn ::core::error::Error>> {
+        let sdl = sdl3::init()?;
+        let video = sdl.video()?;
+        let canvas = video.window_and_renderer("Hello callbacks api!", 640, 480)?;
+        Ok(Self {
+            main: MainThreadData::assert_new(MainData {
+                canvas,
+                _video: video,
+                _sdl: sdl,
+            }),
+            mx: 0.0,
+            my: 0.0,
+        })
+    }
+
+    fn app_init() -> AppResultWithState<Box<Mutex<Self>>> {
+        match Self::new() {
+            Ok(app) => AppResultWithState::Continue(Box::new(Mutex::new(app))),
+            Err(err) => {
+                let error_msg = format!("Error initializing SDL: {err:?}");
+                eprintln!("{error_msg}");
+                let _ = show_simple_message_box(MessageBoxFlag::ERROR, "Error!", &error_msg, None);
+                AppResultWithState::Failure(None)
+            }
+        }
+    }
+
+    fn app_iterate(&mut self) {
+        let main = self.main.assert_get_mut();
+        let canvas = &mut main.canvas;
+
+        canvas.set_draw_color(Color::BLACK);
+        canvas.clear();
+        canvas.set_draw_color(Color::WHITE);
+        let _ = canvas.draw_debug_text(&format!("Callbacks running for {} ms", ticks()), (4, 4));
+        let _ = canvas.draw_debug_text(&format!("Mouse x: {}", self.mx), (4, 20));
+        let _ = canvas.draw_debug_text(&format!("      y: {}", self.my), (4, 28));
+        canvas.present();
+    }
+
+    // event can also be taken by value or by mut reference
+    fn app_event(&mut self, event: &Event) -> AppResult {
+        match event {
+            Event::Quit { .. }
+            | Event::KeyDown {
+                keycode: Some(Keycode::Escape),
+                ..
+            } => AppResult::Success,
+
+            Event::MouseMotion { x, y, .. } => {
+                self.mx = *x;
+                self.my = *y;
+                AppResult::Continue
+            }
+
+            _ => AppResult::Continue,
+        }
+    }
+
+    // app_quit is optional if dropping App does sufficient cleanup
+}

--- a/src/sdl3/lib.rs
+++ b/src/sdl3/lib.rs
@@ -150,6 +150,9 @@ pub mod mixer;
 #[cfg(feature = "ttf")]
 pub mod ttf;
 
+#[cfg(feature = "main")]
+mod sdlmain; // this just implements traits, so it doesn't have to be public
+
 mod common;
 // Export return types and such from the common module.
 pub use crate::common::IntegerOrSdlError;

--- a/src/sdl3/sdlmain.rs
+++ b/src/sdl3/sdlmain.rs
@@ -1,0 +1,27 @@
+//! This implements the necessary traits from the sdl3-main crate so that the app_event
+//! callback can take the Event type from this crate directly
+
+use crate::event::Event;
+use crate::sys::events::SDL_Event;
+use sdl3_main::app::{PassEventMut, PassEventRef, PassEventVal};
+
+impl PassEventVal for Event {
+    #[inline(always)]
+    fn pass_event_val<R>(event: &mut SDL_Event, f: impl FnOnce(Self) -> R) -> R {
+        f(Event::from_ll(*event))
+    }
+}
+
+impl PassEventRef for Event {
+    #[inline(always)]
+    fn pass_event_ref<R>(event: &mut SDL_Event, f: impl FnOnce(&Self) -> R) -> R {
+        f(&Event::from_ll(*event))
+    }
+}
+
+impl PassEventMut for Event {
+    #[inline(always)]
+    fn pass_event_mut<R>(event: &mut SDL_Event, f: impl FnOnce(&mut Self) -> R) -> R {
+        f(&mut Event::from_ll(*event))
+    }
+}


### PR DESCRIPTION
This adds support for SDL's callbacks interface via the sdl3-main crate. The sdl3-main crate does most of the work, but it needs some traits implemented to be able to use the sdl3 crate's Event type in callbacks.

I added an example to show how it's used, too.