### PR TITLE
fix: add compile error for non-functional gfx feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]
 default = []
 unsafe_textures = []
+# DEPRECATED: gfx feature is non-functional - SDL_gfx has not been ported to SDL3 yet.
+# See: https://github.com/vhspace/sdl3-rs/issues/160
 gfx = ["c_vec"] #, "sdl3-sys/gfx"]
 mixer = []
 image = ["dep:sdl3-image-sys"]

--- a/src/sdl3/gfx/mod.rs
+++ b/src/sdl3/gfx/mod.rs
@@ -24,6 +24,11 @@
 //! features = ["gfx"]
 //! ```
 
+compile_error!(
+    "The 'gfx' feature is non-functional. SDL_gfx has not been ported to SDL3 yet. \
+     See: https://github.com/vhspace/sdl3-rs/issues/160"
+);
+
 pub mod framerate;
 pub mod imagefilter;
 pub mod primitives;


### PR DESCRIPTION
Closes #160

SDL_gfx has not been ported to SDL3 yet. Added compile_error! to give users a clear message when they try to enable the gfx feature.