### PR TITLE
chore: Make Event::to_ll public

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -1169,7 +1169,9 @@ impl Event {
         id.0
     }
 
-    fn to_ll(&self) -> Option<sys::events::SDL_Event> {
+    // Required to be public since this is a wrapper on FFI and access to low level
+    // data types might be required for other dependencies
+    pub fn to_ll(&self) -> Option<sys::events::SDL_Event> {
         let mut ret = mem::MaybeUninit::uninit();
         match *self {
             Event::User {


### PR DESCRIPTION
Low-level access might be required by other dependencies, so `to_ll` should not be removed and actually made public.

Since we can't make low level access safe, if we want to avoid issues like the comment on top of `impl Event` tries to warn, we should make them unsafe to require an extra layer of carefulness from the developer using these. Removing them will be a problem when integrating with other dependencies that expect to interact with sdl-sys FFI directly (e.g.: `dear-imgui-rs` used the backend code from `dear-imgui` original C++ codebase, which requires access to the low level SDL).