### PR TITLE
fix: restore audio-queue-squarewave and audio-wav examples

### DIFF
--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -1,85 +1,62 @@
 extern crate sdl3;
 
-// NOTE: You probably want to investigate the
-// mixer feature for real use cases.
+use sdl3::audio::{AudioSpec, AudioSpecWAV};
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-struct Sound {
-    data: Vec<u8>,
-    volume: f32,
-    pos: usize,
-}
-
-// FIXME: Adapt to new playback api.
-#[cfg(any())]
-impl AudioCallback<u8> for Sound {
-    fn callback(&mut self, out: &[u8]) {
-        for dst in out.iter_mut() {
-            // With channel type u8 the "silence" value is 128 (middle of the 0-2^8 range) so we need
-            // to both fill in the silence and scale the wav data accordingly. Filling the silence
-            // once the wav is finished is trivial, applying the volume is more tricky. We need to:
-            // * Change the range of the values from [0, 255] to [-128, 127] so we can multiply
-            // * Apply the volume by multiplying, this gives us range [-128*volume, 127*volume]
-            // * Move the resulting range to a range centered around the value 128, the final range
-            //   is [128 - 128*volume, 128 + 127*volume] – scaled and correctly positioned
-            //
-            // Using value 0 instead of 128 would result in clicking. Scaling by simply multiplying
-            // would not give correct results.
-            let pre_scale = *self.data.get(self.pos).unwrap_or(&128);
-            let scaled_signed_float = (pre_scale as f32 - 128.0) * self.volume;
-            let scaled = (scaled_signed_float + 128.0) as u8;
-            *dst = scaled;
-            self.pos += 1;
-        }
-    }
-}
-
-// FIXME: Convert to AudioStream library
-fn main() {}
-#[cfg(any())]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wav_file: Cow<'static, Path> = match std::env::args().nth(1) {
         None => Cow::from(Path::new("./assets/sine.wav")),
         Some(s) => Cow::from(PathBuf::from(s)),
     };
+
     let sdl_context = sdl3::init()?;
     let audio_subsystem = sdl_context.audio()?;
 
-    let desired_spec = AudioSpecDesired {
-        freq: Some(44_100),
-        channels: Some(1), // mono
-        samples: None,     // default
+    // Load the WAV file
+    let wav = AudioSpecWAV::load_wav(&wav_file)?;
+    println!(
+        "Loaded WAV: {} Hz, {} channels, {:?}",
+        wav.freq, wav.channels, wav.format
+    );
+
+    // Create an audio spec matching the WAV file
+    let wav_spec = AudioSpec {
+        freq: Some(wav.freq),
+        channels: Some(wav.channels as i32),
+        format: Some(wav.format),
     };
 
-    let device = audio_subsystem.open_playback(None, &desired_spec, |spec| {
-        let wav = AudioSpecWAV::load_wav(wav_file).expect("Could not load test WAV file");
+    // Open a playback device and create a stream for it
+    // SDL will handle any necessary format conversion
+    let device = audio_subsystem.open_playback_device(&wav_spec)?;
+    let stream = device.open_device_stream(Some(&wav_spec))?;
 
-        let cvt = AudioCVT::new(
-            wav.format,
-            wav.channels,
-            wav.freq,
-            spec.format,
-            spec.channels,
-            spec.freq,
-        )
-        .expect("Could not convert WAV file");
-
-        let data = cvt.convert(wav.buffer().to_vec());
-
-        // initialize the audio callback
-        Sound {
-            data: data,
-            volume: 0.25,
-            pos: 0,
-        }
-    })?;
+    // Queue the WAV data
+    stream.put_data(wav.buffer())?;
 
     // Start playback
-    device.resume();
+    stream.resume()?;
 
-    // Play for a second
-    std::thread::sleep(Duration::from_millis(1_000));
+    // Play for the duration of the audio (estimate based on buffer size)
+    // For a more accurate duration, calculate from sample rate and buffer length
+    let bytes_per_sample = match wav.format {
+        sdl3::audio::AudioFormat::U8 | sdl3::audio::AudioFormat::S8 => 1,
+        sdl3::audio::AudioFormat::S16LE | sdl3::audio::AudioFormat::S16BE => 2,
+        sdl3::audio::AudioFormat::S32LE
+        | sdl3::audio::AudioFormat::S32BE
+        | sdl3::audio::AudioFormat::F32LE
+        | sdl3::audio::AudioFormat::F32BE => 4,
+        _ => 2, // default assumption
+    };
+    let total_samples = wav.buffer().len() / (bytes_per_sample * wav.channels as usize);
+    let duration_ms = (total_samples as u64 * 1000) / wav.freq as u64;
 
-    // Device is automatically closed when dropped
+    println!("Playing for {} ms...", duration_ms);
+    std::thread::sleep(Duration::from_millis(duration_ms + 100)); // add a small buffer
+
+    // Stream and device are automatically closed when dropped
 
     Ok(())
 }


### PR DESCRIPTION
Both examples were disabled with `#[cfg(any())]` because they used the old SDL2 audio API (like `open_queue`, `AudioSpecDesired`, `AudioCVT`).

Updated them to use the SDL3 AudioStream API:
- `audio-queue-squarewave.rs`: Uses `open_playback_device` + `open_device_stream` + `put_data_i16`
- `audio-wav.rs`: Loads WAV with `AudioSpecWAV::load_wav`, creates matching stream, queues buffer