### PR TITLE
fix: remove unsafe transmutes and improve type safety

### DIFF
--- a/src/sdl3/gfx/primitives.rs
+++ b/src/sdl3/gfx/primitives.rs
@@ -7,7 +7,6 @@ use libc::c_void;
 use libc::{c_char, c_int};
 use std::convert::TryFrom;
 use std::ffi::CString;
-use std::mem;
 use std::ptr;
 
 /// generic Color type
@@ -16,7 +15,8 @@ pub trait ToColor {
 
     #[inline]
     fn as_u32(&self) -> u32 {
-        unsafe { mem::transmute(self.as_rgba()) }
+        let (r, g, b, a) = self.as_rgba();
+        u32::from_ne_bytes([r, g, b, a])
     }
 }
 
@@ -35,14 +35,15 @@ impl ToColor for (u8, u8, u8, u8) {
 
     #[inline]
     fn as_u32(&self) -> u32 {
-        unsafe { mem::transmute(*self) }
+        u32::from_ne_bytes([self.0, self.1, self.2, self.3])
     }
 }
 
 impl ToColor for u32 {
     #[inline]
     fn as_rgba(&self) -> (u8, u8, u8, u8) {
-        unsafe { mem::transmute(*self) }
+        let bytes = self.to_ne_bytes();
+        (bytes[0], bytes[1], bytes[2], bytes[3])
     }
 
     #[inline]
@@ -55,7 +56,9 @@ impl ToColor for u32 {
 impl ToColor for isize {
     #[inline]
     fn as_rgba(&self) -> (u8, u8, u8, u8) {
-        unsafe { mem::transmute(u32::try_from(*self).expect("Can't convert to Color Type")) }
+        let val = u32::try_from(*self).expect("Can't convert to Color Type");
+        let bytes = val.to_ne_bytes();
+        (bytes[0], bytes[1], bytes[2], bytes[3])
     }
 
     #[inline]

--- a/src/sdl3/keyboard/keycode.rs
+++ b/src/sdl3/keyboard/keycode.rs
@@ -2,7 +2,6 @@
 
 use libc::c_char;
 use std::ffi::{CStr, CString};
-use std::mem::transmute;
 
 use crate::sys;
 use sys::keycode::*;
@@ -568,7 +567,7 @@ impl Keycode {
     ) -> Option<Keycode> {
         unsafe {
             let keycode_id = sys::keyboard::SDL_GetKeyFromScancode(
-                transmute::<u32, sys::scancode::SDL_Scancode>(scancode as u32),
+                sys::scancode::SDL_Scancode(scancode as i32),
                 modstate,
                 key_event,
             );

--- a/src/sdl3/keyboard/scancode.rs
+++ b/src/sdl3/keyboard/scancode.rs
@@ -1,7 +1,6 @@
 #![allow(unreachable_patterns)]
 
 use std::ffi::{CStr, CString};
-use std::mem::transmute;
 
 use crate::sys;
 use crate::sys::scancode::*;
@@ -263,9 +262,8 @@ pub enum Scancode {
 impl Scancode {
     pub fn from_i32(n: i32) -> Option<Scancode> {
         use self::Scancode::*;
-        let n = n as u32;
 
-        Some(match unsafe { transmute::<u32, SDL_Scancode>(n) } {
+        Some(match SDL_Scancode(n) {
             SDL_SCANCODE_UNKNOWN => Unknown,
             SDL_SCANCODE_A => A,
             SDL_SCANCODE_B => B,
@@ -526,7 +524,7 @@ impl Scancode {
 
 impl From<Scancode> for SDL_Scancode {
     fn from(scancode: Scancode) -> SDL_Scancode {
-        unsafe { transmute(scancode as u32) }
+        SDL_Scancode(scancode as i32)
     }
 }
 
@@ -573,8 +571,7 @@ impl Scancode {
         // The name string pointer lives in static, read-only memory.
         // Knowing this, we can always return a string slice.
         unsafe {
-            let buf =
-                sys::keyboard::SDL_GetScancodeName(transmute::<u32, SDL_Scancode>(self as u32));
+            let buf = sys::keyboard::SDL_GetScancodeName(SDL_Scancode(self as i32));
             ::std::str::from_utf8(CStr::from_ptr(buf as *const _).to_bytes()).unwrap()
         }
     }

--- a/src/sdl3/pixels.rs
+++ b/src/sdl3/pixels.rs
@@ -121,6 +121,7 @@ fn pixel_format_details_basic() {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+#[repr(C)]
 pub struct Color {
     pub r: u8,
     pub g: u8,
@@ -235,6 +236,7 @@ impl From<(u8, u8, u8, u8)> for Color {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
 pub struct FColor {
     pub r: f32,
     pub g: f32,

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -638,13 +638,16 @@ pub enum SwapInterval {
     LateSwapTearing = -1,
 }
 
-impl From<i32> for SwapInterval {
-    fn from(i: i32) -> Self {
+impl SwapInterval {
+    /// Converts an i32 to a SwapInterval if valid.
+    ///
+    /// Returns `None` for values other than -1, 0, or 1.
+    pub fn from_i32(i: i32) -> Option<Self> {
         match i {
-            -1 => SwapInterval::LateSwapTearing,
-            0 => SwapInterval::Immediate,
-            1 => SwapInterval::VSync,
-            other => panic!("Invalid value for SwapInterval: {other}; valid values are -1, 0, 1"),
+            -1 => Some(SwapInterval::LateSwapTearing),
+            0 => Some(SwapInterval::Immediate),
+            1 => Some(SwapInterval::VSync),
+            _ => None,
         }
     }
 }
@@ -1257,7 +1260,8 @@ impl VideoSubsystem {
             let mut interval = 0;
             let result = sys::video::SDL_GL_GetSwapInterval(&mut interval);
             if result {
-                Ok(SwapInterval::from(interval))
+                SwapInterval::from_i32(interval)
+                    .ok_or_else(|| Error(format!("Invalid swap interval value: {interval}")))
             } else {
                 Err(get_error())
             }


### PR DESCRIPTION
Backports several soundness and safety fixes from rust-sdl2 (2024-2025).

**Scancode/Keycode transmute removal**
Replaces unsafe `transmute::<u32, SDL_Scancode>()` with safe `SDL_Scancode()` constructor. The transmute was undefined behavior when invalid values were passed. (rust-sdl2 PR #1503)

**ToColor transmute removal**
Replaces `mem::transmute` in the gfx primitives module with safe `u32::from_ne_bytes()` and `to_ne_bytes()` operations. (rust-sdl2 PR #1470)

**SwapInterval safety**
Removes the panicking `From<i32>` implementation and adds `from_i32()` method returning `Option<SwapInterval>`. Callers can now handle invalid values gracefully. (rust-sdl2 PR #1413)

**Color repr(C)**
Adds `#[repr(C)]` to `Color` and `FColor` structs for stable FFI memory layout. (rust-sdl2 PR #1472)