### PR TITLE
refactor: replace lazy_static with std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,12 +515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,7 +901,6 @@ dependencies = [
  "bitflags",
  "c_vec",
  "env_logger",
- "lazy_static",
  "libc",
  "objc2",
  "pollster",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ path = "src/sdl3/lib.rs"
 [dependencies]
 bitflags = "2.10.0"
 libc = "0.2.180"
-lazy_static = "1.4.0"
 
 [dependencies.sdl3-sys]
 version = "0.6"

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::mem::transmute;
 use std::ptr;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::gamepad;
@@ -54,10 +54,8 @@ impl CustomEventTypeMaps {
     }
 }
 
-lazy_static! {
-    static ref CUSTOM_EVENT_TYPES: Mutex<CustomEventTypeMaps> =
-        Mutex::new(CustomEventTypeMaps::new());
-}
+static CUSTOM_EVENT_TYPES: LazyLock<Mutex<CustomEventTypeMaps>> =
+    LazyLock::new(|| Mutex::new(CustomEventTypeMaps::new()));
 
 impl crate::EventSubsystem {
     /// Removes all events in the event queue that match the specified event type.

--- a/src/sdl3/lib.rs
+++ b/src/sdl3/lib.rs
@@ -101,8 +101,6 @@
 extern crate bitflags;
 #[cfg(feature = "gfx")]
 extern crate c_vec;
-#[macro_use]
-extern crate lazy_static;
 pub extern crate libc;
 pub extern crate sdl3_sys as sys;
 // use sdl3_sys as sys;

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,6 +1,4 @@
 extern crate sdl3;
-#[macro_use]
-extern crate lazy_static;
 
 use sdl3::event;
 use std::sync::Mutex;
@@ -8,9 +6,7 @@ use std::sync::Mutex;
 // Since only one `Sdl` context instance can be created at a time, running tests in parallel causes
 // 'Cannot initialize `Sdl` more than once at a time' error. To avoid it, run tests in serial by
 // locking this mutex.
-lazy_static! {
-    static ref CONTEXT_MUTEX: Mutex<()> = Mutex::new(());
-}
+static CONTEXT_MUTEX: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_events() {


### PR DESCRIPTION
In one case, we replace it with LazyLock. In another we didn't need it all since Mutex::new is const since Rust 1.63.


----

There is no `rust-version` in the cargo.toml but since sdl3-sys has an MSRV of Rust 1.85, we can definitely use LazyLock