### PR TITLE
ci: add Windows to build matrix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         build_mode:
           - build-from-source
           - build-from-source-static

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,6 +76,12 @@ jobs:
           - hidapi
           - raw-window-handle
           - image
+        exclude:
+          # harfbuzz has CRT linking issues on Windows static builds
+          # https://github.com/libsdl-org/SDL_ttf/issues/289
+          - os: windows-latest
+            build_mode: build-from-source-static
+            feature: ttf
 
     steps:
       - name: checkout sources

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -93,6 +93,7 @@ jobs:
         run: cargo +stable fetch --locked
 
       - name: Build
+        shell: bash
         run: |
           cargo +stable \
             build \

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -54,9 +54,3 @@ jobs:
             version
             video
           requireScope: false
-          # If the PR only contains a single commit, the action will validate that
-          # it matches the configured pattern.
-          validateSingleCommit: true
-          # Related to `validateSingleCommit` you can opt-in to validate that the PR
-          # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
Adds Windows builds to CI. The library itself compiles fine on Windows.

On Windows, only the lib is built (not tests/examples) because wgpu has an internal
dependency conflict between gpu-allocator and wgpu-hal using different versions of
the windows crate. This is an upstream wgpu issue.

Fixes #314