### PR TITLE
fix: use JoystickId for joystick/gamepad event which fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.186"
 
 [dependencies.sdl3-sys]
 version = "0.6.6"
-features = ["metadata"]
+features = ["metadata", "debug-impls", "display-impls"]
 
 [dependencies.sdl3-image-sys]
 version = "0.6.4"

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut controller = gamepad_joysticks_ids
         .into_iter()
         .find_map(|id| {
-            println!("Attempting to open gamepad {}", id.0);
+            println!("Attempting to open gamepad {}", id);
 
             match gamepad_subsystem.open(id) {
                 Ok(c) => {

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -18,7 +18,7 @@ use crate::gamepad;
 use crate::gamepad::{Axis, Button};
 use crate::get_error;
 use crate::joystick;
-use crate::joystick::HatState;
+use crate::joystick::{HatState, JoystickId};
 use crate::keyboard::Keycode;
 use crate::keyboard::Mod;
 use crate::keyboard::Scancode;
@@ -777,7 +777,7 @@ pub enum Event {
     JoyAxisMotion {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         axis_idx: u8,
         value: i16,
     },
@@ -785,7 +785,7 @@ pub enum Event {
     JoyHatMotion {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         hat_idx: u8,
         state: HatState,
     },
@@ -793,31 +793,31 @@ pub enum Event {
     JoyButtonDown {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         button_idx: u8,
     },
     JoyButtonUp {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         button_idx: u8,
     },
 
     JoyDeviceAdded {
         timestamp: u64,
-        /// The newly added joystick's `joystick_index`
-        which: u32,
+        /// The newly added joystick's instance id
+        which: JoystickId,
     },
     JoyDeviceRemoved {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
     },
 
     ControllerAxisMotion {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
         axis: Axis,
         value: i16,
     },
@@ -825,36 +825,36 @@ pub enum Event {
     ControllerButtonDown {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
         button: Button,
     },
     ControllerButtonUp {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
         button: Button,
     },
 
     ControllerDeviceAdded {
         timestamp: u64,
-        /// The newly added controller's `joystick_index`
-        which: u32,
+        /// The newly added controller's instance id
+        which: JoystickId,
     },
     ControllerDeviceRemoved {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
     },
     ControllerDeviceRemapped {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
     },
 
     ControllerTouchpadDown {
         timestamp: u64,
         /// The joystick instance id
-        which: u32,
+        which: JoystickId,
         /// The index of the touchpad
         touchpad: i32,
         /// The index of the finger on the touchpad
@@ -869,7 +869,7 @@ pub enum Event {
     ControllerTouchpadMotion {
         timestamp: u64,
         /// The joystick instance id
-        which: u32,
+        which: JoystickId,
         /// The index of the touchpad
         touchpad: i32,
         /// The index of the finger on the touchpad
@@ -884,7 +884,7 @@ pub enum Event {
     ControllerTouchpadUp {
         timestamp: u64,
         /// The joystick instance id
-        which: u32,
+        which: JoystickId,
         /// The index of the touchpad
         touchpad: i32,
         /// The index of the finger on the touchpad
@@ -901,7 +901,7 @@ pub enum Event {
     #[cfg(feature = "hidapi")]
     ControllerSensorUpdated {
         timestamp: u64,
-        which: u32,
+        which: JoystickId,
         sensor: crate::sensor::SensorType,
         /// Data from the sensor.
         ///
@@ -1129,8 +1129,8 @@ impl Event {
     }
 
     #[inline]
-    fn joystick_id_to_ll(id: u32) -> sys::joystick::SDL_JoystickID {
-        sys::joystick::SDL_JoystickID(id)
+    fn joystick_id_to_ll(id: JoystickId) -> sys::joystick::SDL_JoystickID {
+        id
     }
 
     #[inline]
@@ -1149,8 +1149,8 @@ impl Event {
     }
 
     #[inline]
-    fn joystick_id_from_ll(id: sys::joystick::SDL_JoystickID) -> u32 {
-        id.0
+    fn joystick_id_from_ll(id: sys::joystick::SDL_JoystickID) -> JoystickId {
+        id
     }
 
     #[inline]
@@ -2356,15 +2356,16 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev1 = Event::JoyButtonDown {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// let ev2 = Event::JoyButtonDown {
     ///     timestamp: 1,
-    ///     which: 1,
+    ///     which: JoystickId::new(1),
     ///     button_idx: 1,
     /// };
     ///
@@ -2430,10 +2431,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::JoyButtonDown {
     ///     timestamp: 12,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// assert!(ev.get_timestamp() == 12);
@@ -2507,10 +2509,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::JoyButtonDown {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// assert!(ev.get_window_id() == None);
@@ -2677,10 +2680,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::ControllerDeviceAdded {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     /// };
     /// assert!(ev.is_controller());
     ///
@@ -2707,10 +2711,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::JoyButtonUp {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// assert!(ev.is_joy());
@@ -3342,7 +3347,7 @@ mod test {
     use crate::video::Display;
 
     use super::super::gamepad::{Axis, Button};
-    use super::super::joystick::HatState;
+    use super::super::joystick::{HatState, JoystickId};
     use super::super::keyboard::{Keycode, Mod, Scancode};
     use super::super::mouse::{MouseButton, MouseState, MouseWheelDirection};
     use super::super::video::Orientation;
@@ -3464,7 +3469,7 @@ mod test {
         {
             let e = Event::JoyAxisMotion {
                 timestamp: 0,
-                which: 1,
+                which: JoystickId::new(1),
                 axis_idx: 1,
                 value: 12,
             };
@@ -3474,7 +3479,7 @@ mod test {
         {
             let e = Event::JoyHatMotion {
                 timestamp: 0,
-                which: 3,
+                which: JoystickId::new(3),
                 hat_idx: 1,
                 state: HatState::Left,
             };
@@ -3484,7 +3489,7 @@ mod test {
         {
             let e = Event::JoyButtonDown {
                 timestamp: 0,
-                which: 0,
+                which: JoystickId::new(0),
                 button_idx: 3,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3493,7 +3498,7 @@ mod test {
         {
             let e = Event::JoyButtonUp {
                 timestamp: 9876,
-                which: 1,
+                which: JoystickId::new(1),
                 button_idx: 2,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3502,7 +3507,7 @@ mod test {
         {
             let e = Event::JoyDeviceAdded {
                 timestamp: 0,
-                which: 1,
+                which: JoystickId::new(1),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3510,7 +3515,7 @@ mod test {
         {
             let e = Event::JoyDeviceRemoved {
                 timestamp: 0,
-                which: 2,
+                which: JoystickId::new(2),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3518,7 +3523,7 @@ mod test {
         {
             let e = Event::ControllerAxisMotion {
                 timestamp: 53,
-                which: 0,
+                which: JoystickId::new(0),
                 axis: Axis::LeftX,
                 value: 3,
             };
@@ -3528,7 +3533,7 @@ mod test {
         {
             let e = Event::ControllerButtonDown {
                 timestamp: 0,
-                which: 1,
+                which: JoystickId::new(1),
                 button: Button::Guide,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3537,7 +3542,7 @@ mod test {
         {
             let e = Event::ControllerButtonUp {
                 timestamp: 654214,
-                which: 0,
+                which: JoystickId::new(0),
                 button: Button::DPadRight,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3546,7 +3551,7 @@ mod test {
         {
             let e = Event::ControllerDeviceAdded {
                 timestamp: 543,
-                which: 3,
+                which: JoystickId::new(3),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3554,7 +3559,7 @@ mod test {
         {
             let e = Event::ControllerDeviceRemoved {
                 timestamp: 555,
-                which: 3,
+                which: JoystickId::new(3),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3562,7 +3567,7 @@ mod test {
         {
             let e = Event::ControllerDeviceRemapped {
                 timestamp: 654,
-                which: 0,
+                which: JoystickId::new(0),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -935,7 +935,7 @@ impl Gamepad {
     #[doc(alias = "SDL_GetGamepadID")]
     pub fn id(&self) -> Result<JoystickId, Error> {
         let result = unsafe { sys::gamepad::SDL_GetGamepadID(self.raw) };
-        if result == 0 {
+        if result.0 == 0 {
             Err(get_error())
         } else {
             Ok(result)

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -13,6 +13,10 @@ use std::fmt;
 use sys::power::{SDL_PowerState, SDL_POWERSTATE_UNKNOWN};
 use sys::stdinc::SDL_free;
 
+/// A unique identifier for a joystick device.
+///
+/// Returned by [`Joystick::id()`] and appears in joystick and gamepad events
+/// to identify the instance that generated the event.
 pub type JoystickId = sys::joystick::SDL_JoystickID;
 
 impl JoystickSubsystem {
@@ -186,14 +190,14 @@ impl Joystick {
     }
 
     #[doc(alias = "SDL_GetJoystickID")]
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> JoystickId {
         let result = unsafe { sys::joystick::SDL_GetJoystickID(self.raw) };
 
-        if result == 0 {
+        if result.0 == 0 {
             // Should only fail if the joystick is NULL.
             panic!("{}", get_error())
         } else {
-            u32::from(result)
+            result
         }
     }
 
@@ -486,8 +490,7 @@ impl Joystick {
     /// Check if a joystick is virtual
     #[doc(alias = "SDL_IsJoystickVirtual")]
     pub fn is_virtual(&self) -> bool {
-        let id = sys::joystick::SDL_JoystickID(self.id());
-        unsafe { sys::joystick::SDL_IsJoystickVirtual(id) }
+        unsafe { sys::joystick::SDL_IsJoystickVirtual(self.id()) }
     }
 
     /// Set a virtual axis state
@@ -692,7 +695,7 @@ pub struct VirtualJoystickConnection {
 impl VirtualJoystickConnection {
     /// Exposes the instance ID of the attached virtual joystick so that it can be opened
     pub fn id(&self) -> JoystickId {
-        sys::joystick::SDL_JoystickID(self.inner.id())
+        self.inner.id()
     }
 }
 
@@ -702,8 +705,7 @@ impl VirtualJoystickConnection {
 impl Drop for VirtualJoystickConnection {
     #[doc(alias = "SDL_DetachVirtualJoystick")]
     fn drop(&mut self) {
-        let id = sys::joystick::SDL_JoystickID(self.inner.id());
-        unsafe { sys::joystick::SDL_DetachVirtualJoystick(id) };
+        unsafe { sys::joystick::SDL_DetachVirtualJoystick(self.inner.id()) };
     }
 }
 


### PR DESCRIPTION
Converts JoystickId from a type alias to a proper newtype struct with Debug, Display, and From trait implementations. 

- JoystickId is now a newtype wrapping SDL_JoystickID
- Implements Debug, Display, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash
- Adds From<u32> and Into<u32> for easy conversion
- Updates all joystick/gamepad events to use JoystickId for their `which` field

**Breaking change**: Event `which` fields now require JoystickId instead of u32. Migration is straightforward using the From/Into impls:

```rust
// Before
Event::JoyButtonDown { which: 0, .. }

// After
Event::JoyButtonDown { which: JoystickId::new(0), .. }
// or
Event::JoyButtonDown { which: 0.into(), .. }
```

Part 1 of 2 for #319. The second PR will rename Controller* events to Gamepad* to match SDL3 terminology.