### PR TITLE
refactor: rename Controller* events to Gamepad* for SDL3 consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.186"
 
 [dependencies.sdl3-sys]
 version = "0.6.6"
-features = ["metadata"]
+features = ["metadata", "debug-impls", "display-impls"]
 
 [dependencies.sdl3-image-sys]
 version = "0.6.4"

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut controller = gamepad_joysticks_ids
         .into_iter()
         .find_map(|id| {
-            println!("Attempting to open gamepad {}", id.0);
+            println!("Attempting to open gamepad {}", id);
 
             match gamepad_subsystem.open(id) {
                 Ok(c) => {

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         use sdl3::gamepad::Axis;
 
         match event {
-            Event::ControllerAxisMotion {
+            Event::GamepadAxisMotion {
                 axis: Axis::TriggerLeft,
                 value: val,
                 ..
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Err(e) => println!("Error setting rumble to ({lo_freq}, {hi_freq}): {e:?}"),
                 }
             }
-            Event::ControllerAxisMotion {
+            Event::GamepadAxisMotion {
                 axis: Axis::TriggerRight,
                 value: val,
                 ..
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Err(e) => println!("Error setting rumble to ({lo_freq}, {hi_freq}): {e:?}"),
                 }
             }
-            Event::ControllerAxisMotion {
+            Event::GamepadAxisMotion {
                 axis, value: val, ..
             } => {
                 // Axis motion is an absolute value in the range
@@ -83,23 +83,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("Axis {axis:?} moved to {val}");
                 }
             }
-            Event::ControllerButtonDown { button, .. } => println!("Button {button:?} down"),
-            Event::ControllerButtonUp { button, .. } => println!("Button {button:?} up"),
-            Event::ControllerTouchpadDown {
+            Event::GamepadButtonDown { button, .. } => println!("Button {button:?} down"),
+            Event::GamepadButtonUp { button, .. } => println!("Button {button:?} up"),
+            Event::GamepadTouchpadDown {
                 touchpad,
                 finger,
                 x,
                 y,
                 ..
             } => println!("Touchpad {touchpad} down finger:{finger} x:{x} y:{y}"),
-            Event::ControllerTouchpadMotion {
+            Event::GamepadTouchpadMotion {
                 touchpad,
                 finger,
                 x,
                 y,
                 ..
             } => println!("Touchpad {touchpad} move finger:{finger} x:{x} y:{y}"),
-            Event::ControllerTouchpadUp {
+            Event::GamepadTouchpadUp {
                 touchpad,
                 finger,
                 x,

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), String> {
             println!("gyro: {:?}, accel: {:?}", gyro_data, accel_data);
         }
 
-        if let Event::ControllerSensorUpdated { .. } = event {
+        if let Event::GamepadSensorUpdated { .. } = event {
             println!("{:?}", event);
         }
 

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -18,7 +18,7 @@ use crate::gamepad;
 use crate::gamepad::{Axis, Button};
 use crate::get_error;
 use crate::joystick;
-use crate::joystick::HatState;
+use crate::joystick::{HatState, JoystickId};
 use crate::keyboard::Keycode;
 use crate::keyboard::Mod;
 use crate::keyboard::Scancode;
@@ -777,7 +777,7 @@ pub enum Event {
     JoyAxisMotion {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         axis_idx: u8,
         value: i16,
     },
@@ -785,7 +785,7 @@ pub enum Event {
     JoyHatMotion {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         hat_idx: u8,
         state: HatState,
     },
@@ -793,31 +793,31 @@ pub enum Event {
     JoyButtonDown {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         button_idx: u8,
     },
     JoyButtonUp {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
         button_idx: u8,
     },
 
     JoyDeviceAdded {
         timestamp: u64,
-        /// The newly added joystick's `joystick_index`
-        which: u32,
+        /// The newly added joystick's instance id
+        which: JoystickId,
     },
     JoyDeviceRemoved {
         timestamp: u64,
         /// The joystick's `id`
-        which: u32,
+        which: JoystickId,
     },
 
     ControllerAxisMotion {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
         axis: Axis,
         value: i16,
     },
@@ -825,36 +825,36 @@ pub enum Event {
     ControllerButtonDown {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
         button: Button,
     },
     ControllerButtonUp {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
         button: Button,
     },
 
     ControllerDeviceAdded {
         timestamp: u64,
-        /// The newly added controller's `joystick_index`
-        which: u32,
+        /// The newly added controller's instance id
+        which: JoystickId,
     },
     ControllerDeviceRemoved {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
     },
     ControllerDeviceRemapped {
         timestamp: u64,
         /// The controller's joystick `id`
-        which: u32,
+        which: JoystickId,
     },
 
     ControllerTouchpadDown {
         timestamp: u64,
         /// The joystick instance id
-        which: u32,
+        which: JoystickId,
         /// The index of the touchpad
         touchpad: i32,
         /// The index of the finger on the touchpad
@@ -869,7 +869,7 @@ pub enum Event {
     ControllerTouchpadMotion {
         timestamp: u64,
         /// The joystick instance id
-        which: u32,
+        which: JoystickId,
         /// The index of the touchpad
         touchpad: i32,
         /// The index of the finger on the touchpad
@@ -884,7 +884,7 @@ pub enum Event {
     ControllerTouchpadUp {
         timestamp: u64,
         /// The joystick instance id
-        which: u32,
+        which: JoystickId,
         /// The index of the touchpad
         touchpad: i32,
         /// The index of the finger on the touchpad
@@ -901,7 +901,7 @@ pub enum Event {
     #[cfg(feature = "hidapi")]
     ControllerSensorUpdated {
         timestamp: u64,
-        which: u32,
+        which: JoystickId,
         sensor: crate::sensor::SensorType,
         /// Data from the sensor.
         ///
@@ -1129,8 +1129,8 @@ impl Event {
     }
 
     #[inline]
-    fn joystick_id_to_ll(id: u32) -> sys::joystick::SDL_JoystickID {
-        sys::joystick::SDL_JoystickID(id)
+    fn joystick_id_to_ll(id: JoystickId) -> sys::joystick::SDL_JoystickID {
+        id
     }
 
     #[inline]
@@ -1149,8 +1149,8 @@ impl Event {
     }
 
     #[inline]
-    fn joystick_id_from_ll(id: sys::joystick::SDL_JoystickID) -> u32 {
-        id.0
+    fn joystick_id_from_ll(id: sys::joystick::SDL_JoystickID) -> JoystickId {
+        id
     }
 
     #[inline]
@@ -2356,15 +2356,16 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev1 = Event::JoyButtonDown {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// let ev2 = Event::JoyButtonDown {
     ///     timestamp: 1,
-    ///     which: 1,
+    ///     which: JoystickId::new(1),
     ///     button_idx: 1,
     /// };
     ///
@@ -2430,10 +2431,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::JoyButtonDown {
     ///     timestamp: 12,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// assert!(ev.get_timestamp() == 12);
@@ -2507,10 +2509,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::JoyButtonDown {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// assert!(ev.get_window_id() == None);
@@ -2677,10 +2680,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::ControllerDeviceAdded {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     /// };
     /// assert!(ev.is_controller());
     ///
@@ -2707,10 +2711,11 @@ impl Event {
     ///
     /// ```
     /// use sdl3::event::Event;
+    /// use sdl3::joystick::JoystickId;
     ///
     /// let ev = Event::JoyButtonUp {
     ///     timestamp: 0,
-    ///     which: 0,
+    ///     which: JoystickId::new(0),
     ///     button_idx: 0,
     /// };
     /// assert!(ev.is_joy());
@@ -3342,7 +3347,7 @@ mod test {
     use crate::video::Display;
 
     use super::super::gamepad::{Axis, Button};
-    use super::super::joystick::HatState;
+    use super::super::joystick::{HatState, JoystickId};
     use super::super::keyboard::{Keycode, Mod, Scancode};
     use super::super::mouse::{MouseButton, MouseState, MouseWheelDirection};
     use super::super::video::Orientation;
@@ -3464,7 +3469,7 @@ mod test {
         {
             let e = Event::JoyAxisMotion {
                 timestamp: 0,
-                which: 1,
+                which: JoystickId::new(1),
                 axis_idx: 1,
                 value: 12,
             };
@@ -3474,7 +3479,7 @@ mod test {
         {
             let e = Event::JoyHatMotion {
                 timestamp: 0,
-                which: 3,
+                which: JoystickId::new(3),
                 hat_idx: 1,
                 state: HatState::Left,
             };
@@ -3484,7 +3489,7 @@ mod test {
         {
             let e = Event::JoyButtonDown {
                 timestamp: 0,
-                which: 0,
+                which: JoystickId::new(0),
                 button_idx: 3,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3493,7 +3498,7 @@ mod test {
         {
             let e = Event::JoyButtonUp {
                 timestamp: 9876,
-                which: 1,
+                which: JoystickId::new(1),
                 button_idx: 2,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3502,7 +3507,7 @@ mod test {
         {
             let e = Event::JoyDeviceAdded {
                 timestamp: 0,
-                which: 1,
+                which: JoystickId::new(1),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3510,7 +3515,7 @@ mod test {
         {
             let e = Event::JoyDeviceRemoved {
                 timestamp: 0,
-                which: 2,
+                which: JoystickId::new(2),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3518,7 +3523,7 @@ mod test {
         {
             let e = Event::ControllerAxisMotion {
                 timestamp: 53,
-                which: 0,
+                which: JoystickId::new(0),
                 axis: Axis::LeftX,
                 value: 3,
             };
@@ -3528,7 +3533,7 @@ mod test {
         {
             let e = Event::ControllerButtonDown {
                 timestamp: 0,
-                which: 1,
+                which: JoystickId::new(1),
                 button: Button::Guide,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3537,7 +3542,7 @@ mod test {
         {
             let e = Event::ControllerButtonUp {
                 timestamp: 654214,
-                which: 0,
+                which: JoystickId::new(0),
                 button: Button::DPadRight,
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
@@ -3546,7 +3551,7 @@ mod test {
         {
             let e = Event::ControllerDeviceAdded {
                 timestamp: 543,
-                which: 3,
+                which: JoystickId::new(3),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3554,7 +3559,7 @@ mod test {
         {
             let e = Event::ControllerDeviceRemoved {
                 timestamp: 555,
-                which: 3,
+                which: JoystickId::new(3),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);
@@ -3562,7 +3567,7 @@ mod test {
         {
             let e = Event::ControllerDeviceRemapped {
                 timestamp: 654,
-                which: 0,
+                which: JoystickId::new(0),
             };
             let e2 = Event::from_ll(e.clone().to_ll().unwrap());
             assert_eq!(e, e2);

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -332,17 +332,17 @@ pub enum EventType {
     JoyDeviceAdded = sys::events::SDL_EVENT_JOYSTICK_ADDED.0,
     JoyDeviceRemoved = sys::events::SDL_EVENT_JOYSTICK_REMOVED.0,
 
-    ControllerAxisMotion = sys::events::SDL_EVENT_GAMEPAD_AXIS_MOTION.0,
-    ControllerButtonDown = sys::events::SDL_EVENT_GAMEPAD_BUTTON_DOWN.0,
-    ControllerButtonUp = sys::events::SDL_EVENT_GAMEPAD_BUTTON_UP.0,
-    ControllerDeviceAdded = sys::events::SDL_EVENT_GAMEPAD_ADDED.0,
-    ControllerDeviceRemoved = sys::events::SDL_EVENT_GAMEPAD_REMOVED.0,
-    ControllerDeviceRemapped = sys::events::SDL_EVENT_GAMEPAD_REMAPPED.0,
-    ControllerTouchpadDown = sys::events::SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN.0,
-    ControllerTouchpadMotion = sys::events::SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION.0,
-    ControllerTouchpadUp = sys::events::SDL_EVENT_GAMEPAD_TOUCHPAD_UP.0,
+    GamepadAxisMotion = sys::events::SDL_EVENT_GAMEPAD_AXIS_MOTION.0,
+    GamepadButtonDown = sys::events::SDL_EVENT_GAMEPAD_BUTTON_DOWN.0,
+    GamepadButtonUp = sys::events::SDL_EVENT_GAMEPAD_BUTTON_UP.0,
+    GamepadAdded = sys::events::SDL_EVENT_GAMEPAD_ADDED.0,
+    GamepadRemoved = sys::events::SDL_EVENT_GAMEPAD_REMOVED.0,
+    GamepadRemapped = sys::events::SDL_EVENT_GAMEPAD_REMAPPED.0,
+    GamepadTouchpadDown = sys::events::SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN.0,
+    GamepadTouchpadMotion = sys::events::SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION.0,
+    GamepadTouchpadUp = sys::events::SDL_EVENT_GAMEPAD_TOUCHPAD_UP.0,
     #[cfg(feature = "hidapi")]
-    ControllerSensorUpdated = sys::events::SDL_EVENT_GAMEPAD_SENSOR_UPDATE.0,
+    GamepadSensorUpdated = sys::events::SDL_EVENT_GAMEPAD_SENSOR_UPDATE.0,
 
     FingerDown = sys::events::SDL_EVENT_FINGER_DOWN.0,
     FingerUp = sys::events::SDL_EVENT_FINGER_UP.0,
@@ -443,17 +443,17 @@ impl TryFrom<u32> for EventType {
             SDL_EVENT_JOYSTICK_ADDED => JoyDeviceAdded,
             SDL_EVENT_JOYSTICK_REMOVED => JoyDeviceRemoved,
 
-            SDL_EVENT_GAMEPAD_AXIS_MOTION => ControllerAxisMotion,
-            SDL_EVENT_GAMEPAD_BUTTON_DOWN => ControllerButtonDown,
-            SDL_EVENT_GAMEPAD_BUTTON_UP => ControllerButtonUp,
-            SDL_EVENT_GAMEPAD_ADDED => ControllerDeviceAdded,
-            SDL_EVENT_GAMEPAD_REMOVED => ControllerDeviceRemoved,
-            SDL_EVENT_GAMEPAD_REMAPPED => ControllerDeviceRemapped,
-            SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN => ControllerTouchpadDown,
-            SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION => ControllerTouchpadMotion,
-            SDL_EVENT_GAMEPAD_TOUCHPAD_UP => ControllerTouchpadUp,
+            SDL_EVENT_GAMEPAD_AXIS_MOTION => GamepadAxisMotion,
+            SDL_EVENT_GAMEPAD_BUTTON_DOWN => GamepadButtonDown,
+            SDL_EVENT_GAMEPAD_BUTTON_UP => GamepadButtonUp,
+            SDL_EVENT_GAMEPAD_ADDED => GamepadAdded,
+            SDL_EVENT_GAMEPAD_REMOVED => GamepadRemoved,
+            SDL_EVENT_GAMEPAD_REMAPPED => GamepadRemapped,
+            SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN => GamepadTouchpadDown,
+            SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION => GamepadTouchpadMotion,
+            SDL_EVENT_GAMEPAD_TOUCHPAD_UP => GamepadTouchpadUp,
             #[cfg(feature = "hidapi")]
-            SDL_EVENT_GAMEPAD_SENSOR_UPDATE => ControllerSensorUpdated,
+            SDL_EVENT_GAMEPAD_SENSOR_UPDATE => GamepadSensorUpdated,
 
             SDL_EVENT_FINGER_DOWN => FingerDown,
             SDL_EVENT_FINGER_UP => FingerUp,
@@ -814,44 +814,44 @@ pub enum Event {
         which: JoystickId,
     },
 
-    ControllerAxisMotion {
+    GamepadAxisMotion {
         timestamp: u64,
-        /// The controller's joystick `id`
+        /// The gamepad's joystick instance id
         which: JoystickId,
         axis: Axis,
         value: i16,
     },
 
-    ControllerButtonDown {
+    GamepadButtonDown {
         timestamp: u64,
-        /// The controller's joystick `id`
+        /// The gamepad's joystick instance id
         which: JoystickId,
         button: Button,
     },
-    ControllerButtonUp {
+    GamepadButtonUp {
         timestamp: u64,
-        /// The controller's joystick `id`
+        /// The gamepad's joystick instance id
         which: JoystickId,
         button: Button,
     },
 
-    ControllerDeviceAdded {
+    GamepadAdded {
         timestamp: u64,
-        /// The newly added controller's instance id
+        /// The newly added gamepad's joystick instance id
         which: JoystickId,
     },
-    ControllerDeviceRemoved {
+    GamepadRemoved {
         timestamp: u64,
-        /// The controller's joystick `id`
+        /// The gamepad's joystick instance id
         which: JoystickId,
     },
-    ControllerDeviceRemapped {
+    GamepadRemapped {
         timestamp: u64,
-        /// The controller's joystick `id`
+        /// The gamepad's joystick instance id
         which: JoystickId,
     },
 
-    ControllerTouchpadDown {
+    GamepadTouchpadDown {
         timestamp: u64,
         /// The joystick instance id
         which: JoystickId,
@@ -866,7 +866,7 @@ pub enum Event {
         /// Normalized in the range 0...1
         pressure: f32,
     },
-    ControllerTouchpadMotion {
+    GamepadTouchpadMotion {
         timestamp: u64,
         /// The joystick instance id
         which: JoystickId,
@@ -881,7 +881,7 @@ pub enum Event {
         /// Normalized in the range 0...1
         pressure: f32,
     },
-    ControllerTouchpadUp {
+    GamepadTouchpadUp {
         timestamp: u64,
         /// The joystick instance id
         which: JoystickId,
@@ -899,7 +899,7 @@ pub enum Event {
 
     /// Triggered when the gyroscope or accelerometer is updated
     #[cfg(feature = "hidapi")]
-    ControllerSensorUpdated {
+    GamepadSensorUpdated {
         timestamp: u64,
         which: JoystickId,
         sensor: crate::sensor::SensorType,
@@ -1568,7 +1568,7 @@ impl Event {
                     Some(ret.assume_init())
                 }
             }
-            Event::ControllerAxisMotion {
+            Event::GamepadAxisMotion {
                 timestamp,
                 which,
                 axis,
@@ -1591,7 +1591,7 @@ impl Event {
                     Some(ret.assume_init())
                 }
             }
-            Event::ControllerButtonDown {
+            Event::GamepadButtonDown {
                 timestamp,
                 which,
                 button,
@@ -1616,7 +1616,7 @@ impl Event {
                 }
             }
 
-            Event::ControllerButtonUp {
+            Event::GamepadButtonUp {
                 timestamp,
                 which,
                 button,
@@ -1639,7 +1639,7 @@ impl Event {
                 }
             }
 
-            Event::ControllerDeviceAdded { timestamp, which } => {
+            Event::GamepadAdded { timestamp, which } => {
                 let event = SDL_GamepadDeviceEvent {
                     r#type: sys::events::SDL_EVENT_GAMEPAD_ADDED,
                     timestamp,
@@ -1656,7 +1656,7 @@ impl Event {
                 }
             }
 
-            Event::ControllerDeviceRemoved { timestamp, which } => {
+            Event::GamepadRemoved { timestamp, which } => {
                 let event = SDL_GamepadDeviceEvent {
                     r#type: sys::events::SDL_EVENT_GAMEPAD_REMOVED,
                     timestamp,
@@ -1673,7 +1673,7 @@ impl Event {
                 }
             }
 
-            Event::ControllerDeviceRemapped { timestamp, which } => {
+            Event::GamepadRemapped { timestamp, which } => {
                 let event = SDL_GamepadDeviceEvent {
                     r#type: sys::events::SDL_EVENT_GAMEPAD_REMAPPED,
                     timestamp,
@@ -1989,61 +1989,61 @@ impl Event {
                     }
                 }
 
-                EventType::ControllerAxisMotion => {
+                EventType::GamepadAxisMotion => {
                     let event = raw.gaxis;
                     let axis = gamepad::Axis::from_ll(transmute(event.axis as i32)).unwrap();
 
-                    Event::ControllerAxisMotion {
+                    Event::GamepadAxisMotion {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         axis,
                         value: event.value,
                     }
                 }
-                EventType::ControllerButtonDown => {
+                EventType::GamepadButtonDown => {
                     let event = raw.gbutton;
                     let button = gamepad::Button::from_ll(transmute(event.button as i32)).unwrap();
 
-                    Event::ControllerButtonDown {
+                    Event::GamepadButtonDown {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         button,
                     }
                 }
-                EventType::ControllerButtonUp => {
+                EventType::GamepadButtonUp => {
                     let event = raw.gbutton;
                     let button = gamepad::Button::from_ll(transmute(event.button as i32)).unwrap();
 
-                    Event::ControllerButtonUp {
+                    Event::GamepadButtonUp {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         button,
                     }
                 }
-                EventType::ControllerDeviceAdded => {
+                EventType::GamepadAdded => {
                     let event = raw.gdevice;
-                    Event::ControllerDeviceAdded {
+                    Event::GamepadAdded {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                     }
                 }
-                EventType::ControllerDeviceRemoved => {
+                EventType::GamepadRemoved => {
                     let event = raw.gdevice;
-                    Event::ControllerDeviceRemoved {
+                    Event::GamepadRemoved {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                     }
                 }
-                EventType::ControllerDeviceRemapped => {
+                EventType::GamepadRemapped => {
                     let event = raw.gdevice;
-                    Event::ControllerDeviceRemapped {
+                    Event::GamepadRemapped {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                     }
                 }
-                EventType::ControllerTouchpadDown => {
+                EventType::GamepadTouchpadDown => {
                     let event = raw.gtouchpad;
-                    Event::ControllerTouchpadDown {
+                    Event::GamepadTouchpadDown {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         touchpad: event.touchpad,
@@ -2053,9 +2053,9 @@ impl Event {
                         pressure: event.pressure,
                     }
                 }
-                EventType::ControllerTouchpadMotion => {
+                EventType::GamepadTouchpadMotion => {
                     let event = raw.gtouchpad;
-                    Event::ControllerTouchpadMotion {
+                    Event::GamepadTouchpadMotion {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         touchpad: event.touchpad,
@@ -2065,9 +2065,9 @@ impl Event {
                         pressure: event.pressure,
                     }
                 }
-                EventType::ControllerTouchpadUp => {
+                EventType::GamepadTouchpadUp => {
                     let event = raw.gtouchpad;
-                    Event::ControllerTouchpadUp {
+                    Event::GamepadTouchpadUp {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         touchpad: event.touchpad,
@@ -2078,9 +2078,9 @@ impl Event {
                     }
                 }
                 #[cfg(feature = "hidapi")]
-                EventType::ControllerSensorUpdated => {
+                EventType::GamepadSensorUpdated => {
                     let event = raw.gsensor;
-                    Event::ControllerSensorUpdated {
+                    Event::GamepadSensorUpdated {
                         timestamp: event.timestamp,
                         which: Self::joystick_id_from_ll(event.which),
                         sensor: crate::sensor::SensorType::from_ll(event.sensor),
@@ -2397,12 +2397,15 @@ impl Event {
             | (Self::JoyButtonUp { .. }, Self::JoyButtonUp { .. })
             | (Self::JoyDeviceAdded { .. }, Self::JoyDeviceAdded { .. })
             | (Self::JoyDeviceRemoved { .. }, Self::JoyDeviceRemoved { .. })
-            | (Self::ControllerAxisMotion { .. }, Self::ControllerAxisMotion { .. })
-            | (Self::ControllerButtonDown { .. }, Self::ControllerButtonDown { .. })
-            | (Self::ControllerButtonUp { .. }, Self::ControllerButtonUp { .. })
-            | (Self::ControllerDeviceAdded { .. }, Self::ControllerDeviceAdded { .. })
-            | (Self::ControllerDeviceRemoved { .. }, Self::ControllerDeviceRemoved { .. })
-            | (Self::ControllerDeviceRemapped { .. }, Self::ControllerDeviceRemapped { .. })
+            | (Self::GamepadAxisMotion { .. }, Self::GamepadAxisMotion { .. })
+            | (Self::GamepadButtonDown { .. }, Self::GamepadButtonDown { .. })
+            | (Self::GamepadButtonUp { .. }, Self::GamepadButtonUp { .. })
+            | (Self::GamepadAdded { .. }, Self::GamepadAdded { .. })
+            | (Self::GamepadRemoved { .. }, Self::GamepadRemoved { .. })
+            | (Self::GamepadRemapped { .. }, Self::GamepadRemapped { .. })
+            | (Self::GamepadTouchpadDown { .. }, Self::GamepadTouchpadDown { .. })
+            | (Self::GamepadTouchpadMotion { .. }, Self::GamepadTouchpadMotion { .. })
+            | (Self::GamepadTouchpadUp { .. }, Self::GamepadTouchpadUp { .. })
             | (Self::FingerDown { .. }, Self::FingerDown { .. })
             | (Self::FingerUp { .. }, Self::FingerUp { .. })
             | (Self::FingerMotion { .. }, Self::FingerMotion { .. })
@@ -2420,7 +2423,7 @@ impl Event {
             | (Self::User { .. }, Self::User { .. })
             | (Self::Unknown { .. }, Self::Unknown { .. }) => true,
             #[cfg(feature = "hidapi")]
-            (Self::ControllerSensorUpdated { .. }, Self::ControllerSensorUpdated { .. }) => true,
+            (Self::GamepadSensorUpdated { .. }, Self::GamepadSensorUpdated { .. }) => true,
             _ => false,
         }
     }
@@ -2465,17 +2468,17 @@ impl Event {
             Self::JoyButtonUp { timestamp, .. } => timestamp,
             Self::JoyDeviceAdded { timestamp, .. } => timestamp,
             Self::JoyDeviceRemoved { timestamp, .. } => timestamp,
-            Self::ControllerAxisMotion { timestamp, .. } => timestamp,
-            Self::ControllerButtonDown { timestamp, .. } => timestamp,
-            Self::ControllerButtonUp { timestamp, .. } => timestamp,
-            Self::ControllerDeviceAdded { timestamp, .. } => timestamp,
-            Self::ControllerDeviceRemoved { timestamp, .. } => timestamp,
-            Self::ControllerDeviceRemapped { timestamp, .. } => timestamp,
-            Self::ControllerTouchpadDown { timestamp, .. } => timestamp,
-            Self::ControllerTouchpadMotion { timestamp, .. } => timestamp,
-            Self::ControllerTouchpadUp { timestamp, .. } => timestamp,
+            Self::GamepadAxisMotion { timestamp, .. } => timestamp,
+            Self::GamepadButtonDown { timestamp, .. } => timestamp,
+            Self::GamepadButtonUp { timestamp, .. } => timestamp,
+            Self::GamepadAdded { timestamp, .. } => timestamp,
+            Self::GamepadRemoved { timestamp, .. } => timestamp,
+            Self::GamepadRemapped { timestamp, .. } => timestamp,
+            Self::GamepadTouchpadDown { timestamp, .. } => timestamp,
+            Self::GamepadTouchpadMotion { timestamp, .. } => timestamp,
+            Self::GamepadTouchpadUp { timestamp, .. } => timestamp,
             #[cfg(feature = "hidapi")]
-            Self::ControllerSensorUpdated { timestamp, .. } => timestamp,
+            Self::GamepadSensorUpdated { timestamp, .. } => timestamp,
             Self::FingerDown { timestamp, .. } => timestamp,
             Self::FingerUp { timestamp, .. } => timestamp,
             Self::FingerMotion { timestamp, .. } => timestamp,
@@ -2674,7 +2677,7 @@ impl Event {
         )
     }
 
-    /// Returns `true` if this is a controller event.
+    /// Returns `true` if this is a gamepad event.
     ///
     /// # Example
     ///
@@ -2682,27 +2685,40 @@ impl Event {
     /// use sdl3::event::Event;
     /// use sdl3::joystick::JoystickId;
     ///
-    /// let ev = Event::ControllerDeviceAdded {
+    /// let ev = Event::GamepadAdded {
     ///     timestamp: 0,
     ///     which: JoystickId::new(0),
     /// };
-    /// assert!(ev.is_controller());
+    /// assert!(ev.is_gamepad());
     ///
     /// let another_ev = Event::Quit {
     ///     timestamp: 0,
     /// };
-    /// assert!(another_ev.is_controller() == false); // Not a controller event!
+    /// assert!(another_ev.is_gamepad() == false); // Not a gamepad event!
     /// ```
+    pub fn is_gamepad(&self) -> bool {
+        match self {
+            Self::GamepadAxisMotion { .. }
+            | Self::GamepadButtonDown { .. }
+            | Self::GamepadButtonUp { .. }
+            | Self::GamepadAdded { .. }
+            | Self::GamepadRemoved { .. }
+            | Self::GamepadRemapped { .. }
+            | Self::GamepadTouchpadDown { .. }
+            | Self::GamepadTouchpadMotion { .. }
+            | Self::GamepadTouchpadUp { .. } => true,
+            #[cfg(feature = "hidapi")]
+            Self::GamepadSensorUpdated { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this is a gamepad event.
+    ///
+    /// **Deprecated**: Use [`is_gamepad()`](Self::is_gamepad) instead.
+    #[deprecated(since = "0.18.0", note = "renamed to is_gamepad()")]
     pub fn is_controller(&self) -> bool {
-        matches!(
-            self,
-            Self::ControllerAxisMotion { .. }
-                | Self::ControllerButtonDown { .. }
-                | Self::ControllerButtonUp { .. }
-                | Self::ControllerDeviceAdded { .. }
-                | Self::ControllerDeviceRemoved { .. }
-                | Self::ControllerDeviceRemapped { .. }
-        )
+        self.is_gamepad()
     }
 
     /// Returns `true` if this is a joy event.
@@ -3521,7 +3537,7 @@ mod test {
             assert_eq!(e, e2);
         }
         {
-            let e = Event::ControllerAxisMotion {
+            let e = Event::GamepadAxisMotion {
                 timestamp: 53,
                 which: JoystickId::new(0),
                 axis: Axis::LeftX,
@@ -3531,7 +3547,7 @@ mod test {
             assert_eq!(e, e2);
         }
         {
-            let e = Event::ControllerButtonDown {
+            let e = Event::GamepadButtonDown {
                 timestamp: 0,
                 which: JoystickId::new(1),
                 button: Button::Guide,
@@ -3540,7 +3556,7 @@ mod test {
             assert_eq!(e, e2);
         }
         {
-            let e = Event::ControllerButtonUp {
+            let e = Event::GamepadButtonUp {
                 timestamp: 654214,
                 which: JoystickId::new(0),
                 button: Button::DPadRight,
@@ -3549,7 +3565,7 @@ mod test {
             assert_eq!(e, e2);
         }
         {
-            let e = Event::ControllerDeviceAdded {
+            let e = Event::GamepadAdded {
                 timestamp: 543,
                 which: JoystickId::new(3),
             };
@@ -3557,7 +3573,7 @@ mod test {
             assert_eq!(e, e2);
         }
         {
-            let e = Event::ControllerDeviceRemoved {
+            let e = Event::GamepadRemoved {
                 timestamp: 555,
                 which: JoystickId::new(3),
             };
@@ -3565,7 +3581,7 @@ mod test {
             assert_eq!(e, e2);
         }
         {
-            let e = Event::ControllerDeviceRemapped {
+            let e = Event::GamepadRemapped {
                 timestamp: 654,
                 which: JoystickId::new(0),
             };

--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -1130,7 +1130,7 @@ impl Event {
 
     #[inline]
     fn joystick_id_to_ll(id: JoystickId) -> sys::joystick::SDL_JoystickID {
-        id
+        id.into()
     }
 
     #[inline]
@@ -1150,7 +1150,7 @@ impl Event {
 
     #[inline]
     fn joystick_id_from_ll(id: sys::joystick::SDL_JoystickID) -> JoystickId {
-        id
+        JoystickId::from(id)
     }
 
     #[inline]

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -69,7 +69,7 @@ impl GamepadSubsystem {
                 let mut instances = Vec::new();
                 for i in 0..num_gamepads {
                     let id = *gamepad_ids.offset(i as isize);
-                    instances.push(id);
+                    instances.push(JoystickId::from(id));
                 }
                 sys::stdinc::SDL_free(gamepad_ids as *mut c_void);
                 Ok(instances)
@@ -81,7 +81,7 @@ impl GamepadSubsystem {
     #[inline]
     #[doc(alias = "SDL_IsGamepad")]
     pub fn is_gamepad(&self, joystick_id: JoystickId) -> bool {
-        unsafe { sys::gamepad::SDL_IsGamepad(joystick_id) }
+        unsafe { sys::gamepad::SDL_IsGamepad(joystick_id.into()) }
     }
 
     /// Return true if there's any gamepad connected
@@ -96,7 +96,7 @@ impl GamepadSubsystem {
     /// be retrieved using the `SDL_GetJoysticks` function.
     #[doc(alias = "SDL_OpenGamepad")]
     pub fn open(&self, joystick_id: JoystickId) -> Result<Gamepad, Error> {
-        let gamepad = unsafe { sys::gamepad::SDL_OpenGamepad(joystick_id) };
+        let gamepad = unsafe { sys::gamepad::SDL_OpenGamepad(joystick_id.into()) };
 
         if gamepad.is_null() {
             Err(get_error())
@@ -111,7 +111,7 @@ impl GamepadSubsystem {
     /// Attempt to get the opened gamepad at index `joystick_id` and return it.
     #[doc(alias = "SDL_GetGamepad")]
     pub fn get(&self, joystick_id: JoystickId) -> Result<Gamepad, Error> {
-        let gamepad = unsafe { sys::gamepad::SDL_GetGamepadFromID(joystick_id) };
+        let gamepad = unsafe { sys::gamepad::SDL_GetGamepadFromID(joystick_id.into()) };
 
         if gamepad.is_null() {
             Err(get_error())
@@ -143,7 +143,7 @@ impl GamepadSubsystem {
     #[doc(alias = "SDL_GetGamepadNameForID")]
     pub fn name_for_id(&self, joystick_id: JoystickId) -> Result<String, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let c_str = unsafe { sys::gamepad::SDL_GetGamepadNameForID(joystick_id) };
+        let c_str = unsafe { sys::gamepad::SDL_GetGamepadNameForID(joystick_id.into()) };
 
         if c_str.is_null() {
             Err(SdlError(get_error()))
@@ -161,7 +161,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadPathForID")]
     pub fn path_for_id(&self, joystick_id: JoystickId) -> Result<String, Error> {
-        let c_str = unsafe { sys::gamepad::SDL_GetGamepadPathForID(joystick_id) };
+        let c_str = unsafe { sys::gamepad::SDL_GetGamepadPathForID(joystick_id.into()) };
         c_str_to_string_or_err(c_str)
     }
 
@@ -169,7 +169,8 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadPlayerForID")]
     pub fn player_index_for_id(&self, joystick_id: JoystickId) -> Option<u16> {
-        let player_index = unsafe { sys::gamepad::SDL_GetGamepadPlayerIndexForID(joystick_id) };
+        let player_index =
+            unsafe { sys::gamepad::SDL_GetGamepadPlayerIndexForID(joystick_id.into()) };
 
         if player_index == -1 {
             None
@@ -182,7 +183,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadGUIDForID")]
     pub fn guid_for_id(&self, joystick_id: JoystickId) -> Guid {
-        let guid = unsafe { sys::gamepad::SDL_GetGamepadGUIDForID(joystick_id) };
+        let guid = unsafe { sys::gamepad::SDL_GetGamepadGUIDForID(joystick_id.into()) };
         Guid { raw: guid }
     }
 
@@ -190,7 +191,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadVendorForID")]
     pub fn vendor_for_id(&self, joystick_id: JoystickId) -> Option<u16> {
-        let vendor_id = unsafe { sys::gamepad::SDL_GetGamepadVendorForID(joystick_id) };
+        let vendor_id = unsafe { sys::gamepad::SDL_GetGamepadVendorForID(joystick_id.into()) };
         if vendor_id == 0 {
             None
         } else {
@@ -202,7 +203,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadProductForID")]
     pub fn product_for_id(&self, joystick_id: JoystickId) -> Option<u16> {
-        let product_id = unsafe { sys::gamepad::SDL_GetGamepadProductForID(joystick_id) };
+        let product_id = unsafe { sys::gamepad::SDL_GetGamepadProductForID(joystick_id.into()) };
         if product_id == 0 {
             None
         } else {
@@ -214,7 +215,8 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadProductForID")]
     pub fn product_version_for_id(&self, joystick_id: JoystickId) -> Option<u16> {
-        let version = unsafe { sys::gamepad::SDL_GetGamepadProductVersionForID(joystick_id) };
+        let version =
+            unsafe { sys::gamepad::SDL_GetGamepadProductVersionForID(joystick_id.into()) };
         if version == 0 {
             None
         } else {
@@ -226,7 +228,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadTypeForID")]
     pub fn type_for_id(&self, joystick_id: JoystickId) -> GamepadType {
-        let raw_type = unsafe { sys::gamepad::SDL_GetGamepadTypeForID(joystick_id) };
+        let raw_type = unsafe { sys::gamepad::SDL_GetGamepadTypeForID(joystick_id.into()) };
         GamepadType::from_ll(raw_type)
     }
 
@@ -234,7 +236,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetRealGamepadTypeForID")]
     pub fn real_type_for_id(&self, joystick_id: JoystickId) -> GamepadType {
-        let raw_type = unsafe { sys::gamepad::SDL_GetRealGamepadTypeForID(joystick_id) };
+        let raw_type = unsafe { sys::gamepad::SDL_GetRealGamepadTypeForID(joystick_id.into()) };
         GamepadType::from_ll(raw_type)
     }
 
@@ -242,7 +244,7 @@ impl GamepadSubsystem {
     /// This can be called before any gamepads are opened.
     #[doc(alias = "SDL_GetGamepadMappingForID")]
     pub fn mapping_for_id(&self, joystick_id: JoystickId) -> Option<String> {
-        let c_str = unsafe { sys::gamepad::SDL_GetGamepadMappingForID(joystick_id) };
+        let c_str = unsafe { sys::gamepad::SDL_GetGamepadMappingForID(joystick_id.into()) };
         c_str_to_string_or_none(c_str)
     }
 
@@ -259,7 +261,10 @@ impl GamepadSubsystem {
         };
 
         let result = unsafe {
-            sys::gamepad::SDL_SetGamepadMapping(joystick_id, mapping.as_ptr() as *const c_char)
+            sys::gamepad::SDL_SetGamepadMapping(
+                joystick_id.into(),
+                mapping.as_ptr() as *const c_char,
+            )
         };
 
         if !result {
@@ -914,7 +919,10 @@ impl Gamepad {
         };
 
         let result = unsafe {
-            sys::gamepad::SDL_SetGamepadMapping(joystick_id, mapping.as_ptr() as *const c_char)
+            sys::gamepad::SDL_SetGamepadMapping(
+                joystick_id.into(),
+                mapping.as_ptr() as *const c_char,
+            )
         };
 
         if !result {
@@ -938,7 +946,7 @@ impl Gamepad {
         if result.0 == 0 {
             Err(get_error())
         } else {
-            Ok(result)
+            Ok(JoystickId::from(result))
         }
     }
 

--- a/src/sdl3/gamepad.rs
+++ b/src/sdl3/gamepad.rs
@@ -935,7 +935,7 @@ impl Gamepad {
     #[doc(alias = "SDL_GetGamepadID")]
     pub fn id(&self) -> Result<JoystickId, Error> {
         let result = unsafe { sys::gamepad::SDL_GetGamepadID(self.raw) };
-        if result == 0 {
+        if result.0 == 0 {
             Err(get_error())
         } else {
             Ok(result)

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -16,8 +16,65 @@ use sys::stdinc::SDL_free;
 /// A unique identifier for a joystick device.
 ///
 /// Returned by [`Joystick::id()`] and appears in joystick and gamepad events
-/// to identify the instance that generated the event.
-pub type JoystickId = sys::joystick::SDL_JoystickID;
+/// to identify the instance that generated the event. Construct with
+/// [`JoystickId::new`].
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct JoystickId(sys::joystick::SDL_JoystickID);
+
+impl JoystickId {
+    /// Creates a new `JoystickId` from a raw value.
+    #[inline]
+    pub const fn new(id: u32) -> Self {
+        Self(sys::joystick::SDL_JoystickID(id))
+    }
+
+    /// Returns the raw numeric value of this joystick ID.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0 .0
+    }
+}
+
+impl fmt::Debug for JoystickId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("JoystickId").field(&self.raw()).finish()
+    }
+}
+
+impl fmt::Display for JoystickId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.raw())
+    }
+}
+
+impl From<u32> for JoystickId {
+    #[inline]
+    fn from(id: u32) -> Self {
+        Self::new(id)
+    }
+}
+
+impl From<JoystickId> for u32 {
+    #[inline]
+    fn from(id: JoystickId) -> Self {
+        id.raw()
+    }
+}
+
+impl From<sys::joystick::SDL_JoystickID> for JoystickId {
+    #[inline]
+    fn from(id: sys::joystick::SDL_JoystickID) -> Self {
+        Self(id)
+    }
+}
+
+impl From<JoystickId> for sys::joystick::SDL_JoystickID {
+    #[inline]
+    fn from(id: JoystickId) -> Self {
+        id.0
+    }
+}
 
 impl JoystickSubsystem {
     /// Get joystick instance IDs and names.
@@ -32,7 +89,7 @@ impl JoystickSubsystem {
                 let mut instances = Vec::new();
                 for i in 0..num_joysticks {
                     let id = *joystick_ids.offset(i as isize);
-                    instances.push(id);
+                    instances.push(JoystickId::from(id));
                 }
                 SDL_free(joystick_ids as *mut c_void);
                 Ok(instances)
@@ -44,7 +101,7 @@ impl JoystickSubsystem {
     #[doc(alias = "SDL_OpenJoystick")]
     pub fn open(&self, joystick_id: JoystickId) -> Result<Joystick, IntegerOrSdlError> {
         use crate::common::IntegerOrSdlError::*;
-        let joystick = unsafe { sys::joystick::SDL_OpenJoystick(joystick_id) };
+        let joystick = unsafe { sys::joystick::SDL_OpenJoystick(joystick_id.into()) };
 
         if joystick.is_null() {
             Err(SdlError(get_error()))
@@ -79,7 +136,7 @@ impl JoystickSubsystem {
     /// Check if a joystick is virtual
     #[doc(alias = "SDL_IsJoystickVirtual")]
     pub fn is_virtual(&self, joystick_id: JoystickId) -> bool {
-        unsafe { sys::joystick::SDL_IsJoystickVirtual(joystick_id) }
+        unsafe { sys::joystick::SDL_IsJoystickVirtual(joystick_id.into()) }
     }
 
     /// Attach a virtual joystick
@@ -102,7 +159,7 @@ impl JoystickSubsystem {
         if joystick_id.0 == 0 {
             Err(IntegerOrSdlError::SdlError(get_error()))
         } else {
-            let joystick = self.open(joystick_id)?;
+            let joystick = self.open(joystick_id.into())?;
 
             Ok(VirtualJoystickConnection { inner: joystick })
         }
@@ -197,7 +254,7 @@ impl Joystick {
             // Should only fail if the joystick is NULL.
             panic!("{}", get_error())
         } else {
-            result
+            JoystickId::from(result)
         }
     }
 
@@ -490,7 +547,7 @@ impl Joystick {
     /// Check if a joystick is virtual
     #[doc(alias = "SDL_IsJoystickVirtual")]
     pub fn is_virtual(&self) -> bool {
-        unsafe { sys::joystick::SDL_IsJoystickVirtual(self.id()) }
+        unsafe { sys::joystick::SDL_IsJoystickVirtual(self.id().into()) }
     }
 
     /// Set a virtual axis state
@@ -705,7 +762,7 @@ impl VirtualJoystickConnection {
 impl Drop for VirtualJoystickConnection {
     #[doc(alias = "SDL_DetachVirtualJoystick")]
     fn drop(&mut self) {
-        unsafe { sys::joystick::SDL_DetachVirtualJoystick(self.inner.id()) };
+        unsafe { sys::joystick::SDL_DetachVirtualJoystick(self.inner.id().into()) };
     }
 }
 

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -13,6 +13,10 @@ use std::fmt;
 use sys::power::{SDL_PowerState, SDL_POWERSTATE_UNKNOWN};
 use sys::stdinc::SDL_free;
 
+/// A unique identifier for a joystick device.
+///
+/// Returned by [`Joystick::id()`] and appears in joystick and gamepad events
+/// to identify the instance that generated the event.
 pub type JoystickId = sys::joystick::SDL_JoystickID;
 
 impl JoystickSubsystem {
@@ -186,14 +190,14 @@ impl Joystick {
     }
 
     #[doc(alias = "SDL_GetJoystickID")]
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> JoystickId {
         let result = unsafe { sys::joystick::SDL_GetJoystickID(self.raw) };
 
-        if result == 0 {
+        if result.0 == 0 {
             // Should only fail if the joystick is NULL.
             panic!("{}", get_error())
         } else {
-            u32::from(result)
+            result
         }
     }
 
@@ -486,8 +490,7 @@ impl Joystick {
     /// Check if a joystick is virtual
     #[doc(alias = "SDL_IsJoystickVirtual")]
     pub fn is_virtual(&self) -> bool {
-        let id = sys::joystick::SDL_JoystickID(self.id());
-        unsafe { sys::joystick::SDL_IsJoystickVirtual(id) }
+        unsafe { sys::joystick::SDL_IsJoystickVirtual(self.id()) }
     }
 
     /// Set a virtual axis state
@@ -692,7 +695,7 @@ pub struct VirtualJoystickConnection {
 impl VirtualJoystickConnection {
     /// Exposes the instance ID of the attached virtual joystick so that it can be opened
     pub fn id(&self) -> JoystickId {
-        sys::joystick::SDL_JoystickID(self.inner.id())
+        self.inner.id()
     }
 }
 
@@ -702,8 +705,7 @@ impl VirtualJoystickConnection {
 impl Drop for VirtualJoystickConnection {
     #[doc(alias = "SDL_DetachVirtualJoystick")]
     fn drop(&mut self) {
-        let id = sys::joystick::SDL_JoystickID(self.inner.id());
-        unsafe { sys::joystick::SDL_DetachVirtualJoystick(id) };
+        unsafe { sys::joystick::SDL_DetachVirtualJoystick(self.inner.id()) };
     }
 }
 


### PR DESCRIPTION
Renames event types and variants to match SDL3's gamepad terminology:

| Old Name | New Name |
|----------|----------|
| `ControllerAxisMotion` | `GamepadAxisMotion` |
| `ControllerButtonDown` | `GamepadButtonDown` |
| `ControllerButtonUp` | `GamepadButtonUp` |
| `ControllerDeviceAdded` | `GamepadAdded` |
| `ControllerDeviceRemoved` | `GamepadRemoved` |
| `ControllerDeviceRemapped` | `GamepadRemapped` |
| `ControllerTouchpadDown` | `GamepadTouchpadDown` |
| `ControllerTouchpadMotion` | `GamepadTouchpadMotion` |
| `ControllerTouchpadUp` | `GamepadTouchpadUp` |
| `ControllerSensorUpdated` | `GamepadSensorUpdated` |

Also renames `is_controller()` to `is_gamepad()` with a deprecated alias for backward compatibility.

**Breaking change**: Event variant names changed from Controller* to Gamepad*. The deprecated `is_controller()` alias helps migration.

This PR depends on #322 and together they complete #319.