### PR TITLE
feat: add ffi-safe feature for hot-reloading support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]
 default = []
 unsafe_textures = []
-# FFI-safe subsystems for hot-reloading across DLL boundaries
-ffi-safe = []
+# FFI-safe subsystem handles for hot-reloading across DLL boundaries
+ffi-safe-subsystems = []
 # DEPRECATED: gfx feature is non-functional - SDL_gfx has not been ported to SDL3 yet.
 # See: https://github.com/vhspace/sdl3-rs/issues/160
 gfx = ["c_vec"] #, "sdl3-sys/gfx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,8 @@ build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]
 default = []
 unsafe_textures = []
+# FFI-safe subsystems for hot-reloading across DLL boundaries
+ffi-safe = []
 # DEPRECATED: gfx feature is non-functional - SDL_gfx has not been ported to SDL3 yet.
 # See: https://github.com/vhspace/sdl3-rs/issues/160
 gfx = ["c_vec"] #, "sdl3-sys/gfx"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ Not all [SDL3 extension libraries](https://wiki.libsdl.org/SDL3/Libraries) have 
 | SDL_shadercross  | ❌ Not currently supported  |
 | sdl3-main | ✅ Supported  |
 
+# Feature Flags
+
+## `ffi-safe`
+
+Enables FFI-safe subsystem handles for hot-reloading scenarios.
+
+```toml
+[dependencies]
+sdl3 = { version = "0", features = ["ffi-safe"] }
+```
+
+By default, subsystem handles (like `VideoSubsystem`) use static reference counters.
+This is efficient but breaks when handles are passed across DLL/shared library boundaries
+during hot-reloading, because each compilation unit gets its own copy of the static.
+
+With `ffi-safe` enabled, subsystem handles use heap-allocated reference counters and
+`#[repr(C)]` layout, making them safe to pass across FFI boundaries.
+
+**Limitations:**
+- The main `Sdl` context still uses static counters and must remain in the host binary
+- Only subsystem handles should be passed to hot-reloaded code
+- The `Sdl` context must outlive all subsystems
+
 # Contributing
 
 We're looking for people to help get SDL3 support in Rust built, tested, and completed. You can help out!


### PR DESCRIPTION
Adds optional `ffi-safe` feature that changes subsystem structs to use heap-allocated reference counters instead of static counters. This makes subsystem handles safe to pass across DLL boundaries during hot-reloading.

When `ffi-safe` is enabled:
- Structs become `#[repr(C)]` for stable ABI
- Counter is heap-allocated and shared via raw pointer between clones
- Last drop deallocates the counter and quits the subsystem

The `Sdl` context still uses static counters and must remain in the host binary - only subsystem handles should cross the DLL boundary.

Closes #316