### PR TITLE
better crate description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdl3"
-description = "Cross-platform multimedia"
+description = "Bindings to SDL3, a cross-platform library to abstract the platform-specific details for building applications."
 repository = "https://github.com/vhspace/sdl3-rs"
 documentation = "https://docs.rs/sdl3/latest/sdl3/"
 version = "0.17.3"


### PR DESCRIPTION
I added sdl3 to areweguiyet.org https://github.com/areweguiyet/areweguiyet/pull/199 in the hope that it would become more visible as a `winit`/`wgpu` alternative.

Currently the crate description used on the website is somewhat vague. Maybe this one is better?