### PR TITLE
feat: add window_id to finger touch events

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -915,6 +915,7 @@ pub enum Event {
         dx: f32,
         dy: f32,
         pressure: f32,
+        window_id: u32,
     },
     FingerUp {
         timestamp: u64,
@@ -925,6 +926,7 @@ pub enum Event {
         dx: f32,
         dy: f32,
         pressure: f32,
+        window_id: u32,
     },
     FingerMotion {
         timestamp: u64,
@@ -935,6 +937,7 @@ pub enum Event {
         dx: f32,
         dy: f32,
         pressure: f32,
+        window_id: u32,
     },
 
     DollarRecord {
@@ -2089,6 +2092,7 @@ impl Event {
                         dx: event.dx,
                         dy: event.dy,
                         pressure: event.pressure,
+                        window_id: Self::window_id_from_ll(event.windowID),
                     }
                 }
                 EventType::FingerUp => {
@@ -2102,6 +2106,7 @@ impl Event {
                         dx: event.dx,
                         dy: event.dy,
                         pressure: event.pressure,
+                        window_id: Self::window_id_from_ll(event.windowID),
                     }
                 }
                 EventType::FingerMotion => {
@@ -2115,6 +2120,7 @@ impl Event {
                         dx: event.dx,
                         dy: event.dy,
                         pressure: event.pressure,
+                        window_id: Self::window_id_from_ll(event.windowID),
                     }
                 }
 
@@ -2519,6 +2525,9 @@ impl Event {
             Self::MouseButtonDown { window_id, .. } => Some(*window_id),
             Self::MouseButtonUp { window_id, .. } => Some(*window_id),
             Self::MouseWheel { window_id, .. } => Some(*window_id),
+            Self::FingerDown { window_id, .. } => Some(*window_id),
+            Self::FingerUp { window_id, .. } => Some(*window_id),
+            Self::FingerMotion { window_id, .. } => Some(*window_id),
             Self::DropFile { window_id, .. } => Some(*window_id),
             Self::DropText { window_id, .. } => Some(*window_id),
             Self::DropBegin { window_id, .. } => Some(*window_id),
@@ -2730,6 +2739,7 @@ impl Event {
     ///     dx: 0.,
     ///     dy: 0.,
     ///     pressure: 0.,
+    ///     window_id: 0,
     /// };
     /// assert!(ev.is_finger());
     ///


### PR DESCRIPTION
SDL's `SDL_TouchFingerEvent` includes a `windowID` field that tells you which window received the touch input, but the `FingerDown`, `FingerUp`, and `FingerMotion` event variants weren't exposing it. This adds the `window_id: u32` field to all three variants and wires it up in deserialization and `get_window_id()`.

Fixes #350