### PR TITLE
style: remove unnecessary extern crate statements

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,4 +1,3 @@
-extern crate sdl3;
 use std::path::Path;
 
 use sdl3::event::Event;

--- a/examples/audio-capture-and-replay.rs
+++ b/examples/audio-capture-and-replay.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::audio::{AudioCallback, AudioFormat, AudioRecordingCallback, AudioSpec, AudioStream};
 use sdl3::AudioSubsystem;
 use std::i16;

--- a/examples/audio-queue-squarewave.rs
+++ b/examples/audio-queue-squarewave.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::audio::{AudioFormat, AudioSpec};
 use std::time::Duration;
 

--- a/examples/audio-squarewave.rs
+++ b/examples/audio-squarewave.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStream};
 use std::time::Duration;
 

--- a/examples/audio-wav.rs
+++ b/examples/audio-wav.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::audio::{AudioSpec, AudioSpecWAV};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};

--- a/examples/audio-whitenoise.rs
+++ b/examples/audio-whitenoise.rs
@@ -1,6 +1,3 @@
-extern crate rand;
-extern crate sdl3;
-
 use sdl3::audio::{AudioCallback, AudioFormat, AudioSpec, AudioStream};
 use std::time::Duration;
 
@@ -10,7 +7,7 @@ struct MyCallback {
 }
 impl AudioCallback<f32> for MyCallback {
     fn callback(&mut self, stream: &mut AudioStream, requested: i32) {
-        use self::rand::{thread_rng, Rng};
+        use rand::{thread_rng, Rng};
         let mut rng = thread_rng();
 
         self.buffer.resize(requested as usize, 0.0);

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::image::LoadSurface;
 use sdl3::keyboard::Keycode;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::dialog::{
     show_open_file_dialog, show_open_folder_dialog, show_save_file_dialog, DialogFileFilter,
 };

--- a/examples/draw_triangle.rs
+++ b/examples/draw_triangle.rs
@@ -1,7 +1,4 @@
 // https://github.com/tsoding/midpoint-circle-visualization
-
-extern crate sdl3;
-
 use sdl3::{
     event::Event, keyboard::Keycode, pixels::Color, rect::Point, render::Canvas, video::Window,
 };

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;

--- a/examples/filesystem.rs
+++ b/examples/filesystem.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::filesystem::*;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/game-of-life-unsafe-textures.rs
+++ b/examples/game-of-life-unsafe-textures.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 #[cfg(feature = "unsafe_textures")]
 use game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
 #[cfg(feature = "unsafe_textures")]

--- a/examples/game-of-life.rs
+++ b/examples/game-of-life.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 #[cfg(not(feature = "unsafe_textures"))]
 use crate::game_of_life::{PLAYGROUND_HEIGHT, PLAYGROUND_WIDTH, SQUARE_SIZE};
 use sdl3::event::Event;

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This is required for certain controllers to work on Windows without the
     // video subsystem enabled:

--- a/examples/gfx-demo.rs
+++ b/examples/gfx-demo.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels;

--- a/examples/gpu-clear.rs
+++ b/examples/gpu-clear.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 

--- a/examples/gpu-cube.rs
+++ b/examples/gpu-cube.rs
@@ -14,8 +14,6 @@ use sdl3::{
     Error,
 };
 
-extern crate sdl3;
-
 #[repr(packed)]
 #[derive(Copy, Clone)]
 pub struct VertexPosition {

--- a/examples/gpu-texture.rs
+++ b/examples/gpu-texture.rs
@@ -17,8 +17,6 @@ use sdl3::{
 };
 use std::path::Path;
 
-extern crate sdl3;
-
 #[repr(packed)]
 #[derive(Copy, Clone)]
 pub struct Vertex {

--- a/examples/gpu-triangle.rs
+++ b/examples/gpu-triangle.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::{
     event::Event,
     gpu::{

--- a/examples/haptic.rs
+++ b/examples/haptic.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sdl_context = sdl3::init()?;
     let joystick_subsystem = sdl_context.joystick()?;

--- a/examples/image-demo.rs
+++ b/examples/image-demo.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::image::LoadTexture;
 use sdl3::keyboard::Keycode;

--- a/examples/joystick.rs
+++ b/examples/joystick.rs
@@ -1,7 +1,5 @@
 use sdl3::get_error;
 
-extern crate sdl3;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sdl_context = sdl3::init()?;
     let joystick_subsystem = sdl_context.joystick()?;

--- a/examples/keyboard-state.rs
+++ b/examples/keyboard-state.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3_sys::keycode::SDL_KMOD_NONE;

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::log::*;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/message-box.rs
+++ b/examples/message-box.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::messagebox::*;

--- a/examples/mixer-demo.rs
+++ b/examples/mixer-demo.rs
@@ -1,6 +1,4 @@
 /// Demonstrates the simultaneous mixing of music and sound effects.
-extern crate sdl3;
-
 use sdl3::mixer::{InitFlag, AUDIO_S16LSB, DEFAULT_CHANNELS};
 use std::env;
 use std::path::Path;

--- a/examples/mouse-state.rs
+++ b/examples/mouse-state.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use std::collections::HashSet;

--- a/examples/no-renderer.rs
+++ b/examples/no-renderer.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -1,4 +1,3 @@
-extern crate sdl3;
 use std::ptr;
 
 use sdl3::properties::*;

--- a/examples/raw-window-handle-with-wgpu/main.rs
+++ b/examples/raw-window-handle-with-wgpu/main.rs
@@ -1,9 +1,5 @@
 /// Minimal example for getting sdl3 and wgpu working together with raw-window-handle.
 /// For your own code, make sure to add "raw-window-handle" to the features list of sdl3
-extern crate pollster;
-extern crate sdl3;
-extern crate wgpu;
-
 use std::borrow::Cow;
 use wgpu::{InstanceDescriptor, SurfaceError};
 

--- a/examples/relative-mouse-state.rs
+++ b/examples/relative-mouse-state.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::mouse::MouseButton;

--- a/examples/renderer-target.rs
+++ b/examples/renderer-target.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::{Color, PixelFormat};

--- a/examples/renderer-texture.rs
+++ b/examples/renderer-texture.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::PixelFormat;

--- a/examples/renderer-yuv.rs
+++ b/examples/renderer-yuv.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::PixelFormat;

--- a/examples/renderer/a02_primitives.rs
+++ b/examples/renderer/a02_primitives.rs
@@ -1,6 +1,4 @@
 // https://github.com/libsdl-org/SDL/tree/main/examples/renderer
-extern crate sdl3;
-
 use rand::Rng;
 use sdl3::rect::Rect;
 use sdl3::render::FRect;

--- a/examples/renderer/a03_lines.rs
+++ b/examples/renderer/a03_lines.rs
@@ -1,6 +1,3 @@
-extern crate rand;
-extern crate sdl3;
-
 use rand::Rng;
 use sdl3::event::Event;
 use sdl3::pixels::Color;

--- a/examples/renderer/a04_points.rs
+++ b/examples/renderer/a04_points.rs
@@ -1,6 +1,3 @@
-extern crate rand;
-extern crate sdl3;
-
 use rand::Rng;
 use sdl3::event::Event;
 use sdl3::pixels::Color;

--- a/examples/renderer/a05_rectangles.rs
+++ b/examples/renderer/a05_rectangles.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::pixels::Color;
 use sdl3::rect::Rect;

--- a/examples/renderer/a06_textures_lifetime_solution.rs
+++ b/examples/renderer/a06_textures_lifetime_solution.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use std::path::Path;
 
 use sdl3::event::Event;

--- a/examples/renderer/a07_streaming_textures.rs
+++ b/examples/renderer/a07_streaming_textures.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::pixels::PixelFormat;
 use sdl3::render::{Canvas, FRect, Texture};

--- a/examples/renderer/a08_rotating_textures.rs
+++ b/examples/renderer/a08_rotating_textures.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 // use sdl3::pixels::PixelFormat;
 use sdl3::render::FPoint;

--- a/examples/renderer/a09_scaling_textures.rs
+++ b/examples/renderer/a09_scaling_textures.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::render::FRect;
 use sdl3::render::{Canvas, Texture};

--- a/examples/resource-manager.rs
+++ b/examples/resource-manager.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::image::{InitFlag, LoadTexture};
 use sdl3::keyboard::Keycode;

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -1,4 +1,3 @@
-extern crate sdl3;
 use std::time::{Duration, Instant};
 
 use sdl3::{event::Event, sensor::SensorType};

--- a/examples/spinning_cube.rs
+++ b/examples/spinning_cube.rs
@@ -3,8 +3,6 @@
 // orginal code https://www.desmos.com/calculator/vp7yjxkq9h
 // orginal C code https://github.com/servetgulnaroglu/cube.c
 
-extern crate sdl3;
-
 use sdl3::{
     event::Event, keyboard::Keycode, pixels::Color, rect::Point, render::Canvas, video::Window,
 };

--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use std::env;
 use std::path::Path;
 

--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event::Event;
 use sdl3::keyboard::Keycode;
 use sdl3::pixels::Color;

--- a/src/sdl3/lib.rs
+++ b/src/sdl3/lib.rs
@@ -1,8 +1,6 @@
 //! # Getting started
 //!
 //! ```rust,no_run
-//! extern crate sdl3;
-//!
 //! use sdl3::pixels::Color;
 //! use sdl3::event::Event;
 //! use sdl3::keyboard::Keycode;

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 fn init_audio_subsystem() -> Option<(sdl3::Sdl, sdl3::AudioSubsystem)> {
     std::env::set_var("SDL_AUDIODRIVER", "dummy");
     let sdl = match sdl3::init() {

--- a/tests/clipboard.rs
+++ b/tests/clipboard.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 #[test]
 fn test_clipboard() {
     let sdl_context = match sdl3::init() {

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 use sdl3::event;
 use std::sync::Mutex;
 

--- a/tests/iostream.rs
+++ b/tests/iostream.rs
@@ -1,4 +1,3 @@
-extern crate sdl3;
 use std::io::Read;
 
 #[test]

--- a/tests/raw_window_handle.rs
+++ b/tests/raw_window_handle.rs
@@ -1,12 +1,11 @@
 #[cfg(feature = "raw-window-handle")]
 mod raw_window_handle_test {
     extern crate raw_window_handle;
-    extern crate sdl3;
 
     use self::raw_window_handle::{
         HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
     };
-    use self::sdl3::video::Window;
+    use sdl3::video::Window;
 
     #[cfg(target_os = "windows")]
     #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1,4 +1,3 @@
-extern crate sdl3;
 use sdl3::{rect::Rect, render::create_renderer, render::ClippingRect};
 
 #[test]

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,5 +1,3 @@
-extern crate sdl3;
-
 /*
 #[test]
 fn display_name_no_segfault() {


### PR DESCRIPTION
In Rust 2018 edition, `extern crate` is no longer needed "in 99% percent of circumstances." The sdl3-rs tests and examples still say `extern crate sdl3`. This PR removes `extern crate` declarations completely from examples/ and tests/ and also from the example in `src/sdl3/lib.rs`.

One exception is `tests/raw_window_handle.rs`, with `extern crate raw_window_handle`. As I didn't know how to test it properly, I skipped this one.

This PR does not modify the sdl3-rs crate code itself.

The sdl3-rs crate is specified to use 2021 edition in `Cargo.toml`. This does not mean that people can't use 2015 edition in their project and still use this crate. The only reason I see for keeping extern crate declarations is that the examples should support 2015 edition. If this is the case, this PR shouldn't be merged.

According to the documentation for Rust 2018[1]:
> - extern crate is no longer needed in 99% of circumstances.
> ...
> This one is quite straightforward: you no longer need to write extern crate to import a crate into your project.
> ...
> Now, to add a new crate to your project, you can add it to your Cargo.toml, and then there is no step two.

Also see this StackOverflow answer on the subject.[2]

[1]: https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html
[2]: https://stackoverflow.com/questions/29403920/whats-the-difference-between-use-and-extern-crate