### PR TITLE
feat: add SDL3_mixer support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,7 @@ jobs:
           - hidapi
           - raw-window-handle
           - image
+          - mixer
 
     steps:
       - name: checkout sources
@@ -61,7 +62,7 @@ jobs:
   build-version-features:
     name: Build - ${{ matrix.os }} - ${{ matrix.build_mode }} - feature ${{ matrix.feature }}
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +77,7 @@ jobs:
           - hidapi
           - raw-window-handle
           - image
+          - mixer
         exclude:
           # harfbuzz has CRT linking issues on Windows static builds
           # https://github.com/libsdl-org/SDL_ttf/issues/289
@@ -130,6 +132,12 @@ jobs:
           - name: image (build-from-source-static)
             build_mode: build-from-source-static
             features: "image"
+          - name: mixer (build-from-source)
+            build_mode: build-from-source
+            features: "mixer"
+          - name: mixer (build-from-source-static)
+            build_mode: build-from-source-static
+            features: "mixer"
 
     steps:
       - name: checkout sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ dependencies = [
  "raw-window-handle",
  "sdl3-image-sys",
  "sdl3-main",
+ "sdl3-mixer-sys",
  "sdl3-sys",
  "sdl3-ttf-sys",
  "wgpu",
@@ -930,6 +931,24 @@ name = "sdl3-main-macros"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ea7f98211e1fefceafb264fb5638798fb26eca12b194dbc1eff7c6127ea4a6"
+
+[[package]]
+name = "sdl3-mixer-src"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eadf2552e54f487570e82454e325358f8f4ce1b602ce5837206659805c9f2b8"
+
+[[package]]
+name = "sdl3-mixer-sys"
+version = "0.6.1+SDL-mixer-3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f493bd0cf6f2ba15ab5e40dea89ca16fee6e1a6a7926a549a60225ccc033cfee"
+dependencies = [
+ "cmake",
+ "rpkg-config",
+ "sdl3-mixer-src",
+ "sdl3-sys",
+]
 
 [[package]]
 name = "sdl3-src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ optional = true
 version = "0.6"
 optional = true
 
+[dependencies.sdl3-mixer-sys]
+version = "0.6"
+optional = true
+
 [dependencies.sdl3-main]
 version = "0.6"
 optional = true
@@ -76,11 +80,13 @@ build-from-source = [
     "sdl3-sys/build-from-source",
     "sdl3-image-sys?/build-from-source",
     "sdl3-ttf-sys?/build-from-source",
+    "sdl3-mixer-sys?/build-from-source",
 ]
 build-from-source-static = [
     "sdl3-sys/build-from-source-static",
     "sdl3-image-sys?/build-from-source-static",
     "sdl3-ttf-sys?/build-static-vendored",
+    "sdl3-mixer-sys?/build-static-vendored",
 ]
 build-from-source-unix-console = ["sdl3-sys/sdl-unix-console-build"]
 ash = ["sdl3-sys/use-ash-v0-38"]
@@ -89,7 +95,7 @@ unsafe_textures = []
 # DEPRECATED: gfx feature is non-functional - SDL_gfx has not been ported to SDL3 yet.
 # See: https://github.com/vhspace/sdl3-rs/issues/160
 gfx = ["c_vec"] #, "sdl3-sys/gfx"]
-mixer = []
+mixer = ["dep:sdl3-mixer-sys"]
 image = ["dep:sdl3-image-sys"]
 ttf = ["dep:sdl3-ttf-sys"]
 # Use hidapi support in SDL. Only 2.0.12 and after

--- a/examples/mixer-demo.rs
+++ b/examples/mixer-demo.rs
@@ -1,5 +1,7 @@
-/// Demonstrates the simultaneous mixing of music and sound effects.
-use sdl3::mixer::{InitFlag, AUDIO_S16LSB, DEFAULT_CHANNELS};
+/// Demonstrates audio mixing with SDL3_mixer.
+///
+/// Usage: mixer-demo <music_file> [sound_effect_file]
+use sdl3::mixer;
 use std::env;
 use std::path::Path;
 
@@ -7,111 +9,79 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<_> = env::args().collect();
 
     if args.len() < 2 {
-        println!("Usage: ./demo music.[mp3|wav|ogg] [sound-effect.[mp3|wav|ogg]]")
-    } else {
-        let sound_file = args.get(2).map(|sound_file| Path::new(sound_file));
-        demo(Path::new(&args[1]), sound_file)?;
+        println!("Usage: ./mixer-demo music.[mp3|wav|ogg] [sound-effect.[mp3|wav|ogg]]");
+        return Ok(());
     }
 
-    Ok(())
-}
-
-fn demo(music_file: &Path, sound_file: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
-    println!("linked version: {}", sdl3::mixer::get_linked_version());
+    println!("SDL_mixer version: {}", mixer::get_linked_version());
 
     let sdl = sdl3::init()?;
     let _audio = sdl.audio()?;
-    let mut timer = sdl.timer()?;
 
-    let frequency = 44_100;
-    let format = AUDIO_S16LSB; // signed 16 bit samples, in little-endian byte order
-    let channels = DEFAULT_CHANNELS; // Stereo
-    let chunk_size = 1_024;
-    sdl3::mixer::open_audio(frequency, format, channels, chunk_size)?;
-    let _mixer_context =
-        sdl3::mixer::init(InitFlag::MP3 | InitFlag::FLAC | InitFlag::MOD | InitFlag::OGG)?;
+    // Initialize SDL_mixer
+    let _ctx = mixer::init()?;
 
-    // Number of mixing channels available for sound effect `Chunk`s to play
-    // simultaneously.
-    sdl3::mixer::allocate_channels(4);
-
-    {
-        let n = sdl3::mixer::get_chunk_decoders_number();
-        println!("available chunk(sample) decoders: {}", n);
-        for i in 0..n {
-            println!("  decoder {} => {}", i, sdl3::mixer::get_chunk_decoder(i));
+    // List available decoders
+    let n = mixer::get_num_audio_decoders();
+    println!("available audio decoders: {n}");
+    for i in 0..n {
+        if let Some(name) = mixer::get_audio_decoder(i) {
+            println!("  decoder {i} => {name}");
         }
     }
 
-    {
-        let n = sdl3::mixer::get_music_decoders_number();
-        println!("available music decoders: {}", n);
-        for i in 0..n {
-            println!("  decoder {} => {}", i, sdl3::mixer::get_music_decoder(i));
-        }
+    // Create mixer device with default format
+    let mixer_dev = mixer::Mixer::open_device(None)?;
+    let fmt = mixer_dev.format()?;
+    println!("mixer format: {}Hz, {} channels", fmt.freq, fmt.channels);
+
+    // Load music from file
+    let music = mixer_dev.load_audio(Path::new(&args[1]), false)?;
+    println!("music duration: {} frames", music.duration());
+
+    // Create a track and play the music
+    let music_track = mixer_dev.create_track()?;
+    music_track.set_audio(&music)?;
+    music_track.set_loops(-1)?; // loop forever
+    music_track.tag("music")?;
+    music_track.play()?;
+    println!("playing music...");
+
+    // Optionally play a sound effect
+    if let Some(sound_path) = args.get(2) {
+        let sfx = mixer_dev.load_audio(Path::new(sound_path), true)?;
+        let sfx_track = mixer_dev.create_track()?;
+        sfx_track.set_audio(&sfx)?;
+        sfx_track.tag("sfx")?;
+        sfx_track.play()?;
+        println!("playing sound effect...");
+    } else {
+        // Generate a test sine wave
+        let sine = mixer_dev.create_sine_wave(440, 0.25, 2000)?;
+        let sine_track = mixer_dev.create_track()?;
+        sine_track.set_audio(&sine)?;
+        sine_track.tag("sfx")?;
+        sine_track.play()?;
+        println!("playing 440Hz sine wave...");
     }
 
-    println!("query spec => {:?}", sdl3::mixer::query_spec());
+    // Play for a bit
+    std::thread::sleep(std::time::Duration::from_secs(5));
 
-    let music = sdl3::mixer::Music::from_file(music_file)?;
+    // Lower the music volume
+    println!("lowering music volume to 50%...");
+    music_track.set_gain(0.5)?;
+    std::thread::sleep(std::time::Duration::from_secs(3));
 
-    fn hook_finished() {
-        println!("play ends! from rust cb");
-    }
+    // Fade out with a 2-second fade
+    let fade_frames = music_track.ms_to_frames(2000);
+    println!("fading out music...");
+    music_track.stop(fade_frames)?;
+    std::thread::sleep(std::time::Duration::from_secs(3));
 
-    sdl3::mixer::Music::hook_finished(hook_finished);
-
-    println!("music => {:?}", music);
-    println!("music type => {:?}", music.get_type());
-    println!("music volume => {:?}", sdl3::mixer::Music::get_volume());
-    println!("play => {:?}", music.play(1));
-
-    {
-        let sound_chunk = match sound_file {
-            Some(sound_file_path) => sdl3::mixer::Chunk::from_file(sound_file_path)
-                .map_err(|e| format!("Cannot load sound file: {:?}", e))?,
-            None => {
-                // One second of 500Hz sine wave using equation A * sin(2 * PI * f * t)
-                // (played at half the volume to save people's ears).
-                let buffer = (0..frequency)
-                    .map(|i| {
-                        (0.1 * i16::max_value() as f32
-                            * (2.0 * 3.14 * 500.0 * (i as f32 / frequency as f32)).sin())
-                            as i16
-                    })
-                    .collect();
-                sdl3::mixer::Chunk::from_raw_buffer(buffer)
-                    .map_err(|e| format!("Cannot get chunk from buffer: {:?}", e))?
-            }
-        };
-
-        println!("chunk volume => {:?}", sound_chunk.get_volume());
-        println!("playing sound twice");
-        sdl3::mixer::Channel::all().play(&sound_chunk, 1)?;
-
-        // This delay is needed because when the `Chunk` goes out of scope,
-        // the sound effect stops playing. Delay long enough to hear the
-        // sound.
-        timer.delay(5_000);
-        println!("played sound");
-    }
-
-    timer.delay(10_000);
-
-    println!("fading out ... {:?}", sdl3::mixer::Music::fade_out(4_000));
-
-    timer.delay(5_000);
-
-    println!(
-        "fading in from pos ... {:?}",
-        music.fade_in_from_pos(1, 10_000, 100.0)
-    );
-
-    timer.delay(5_000);
-    sdl3::mixer::Music::halt();
-    timer.delay(1_000);
-
-    println!("quitting sdl");
+    // Stop everything
+    mixer_dev.stop_all(0)?;
+    println!("done.");
 
     Ok(())
 }

--- a/src/sdl3/lib.rs
+++ b/src/sdl3/lib.rs
@@ -75,7 +75,7 @@
 //! | `ash`               | Use Vulkan types from the ash crate                                    | Implemented           |
 //! | `unsafe_textures`   | Skip lifetime tracking for textures; you must manage destruction safety yourself | Implemented (unsafe opt-in) |
 //! | `gfx`               | Legacy SDL_gfx drawing helpers; blocked on an SDL3_gfx C library       | Blocked               |
-//! | `mixer`             | SDL_mixer bindings (needs upstream SDL3_mixer and `sdl3-mixer-sys`)    | Blocked               |
+//! | `mixer`             | SDL3_mixer bindings for audio mixing and playback                      | Implemented           |
 //! | `image`             | Enable SDL_image helpers for loading/saving surfaces and textures      | Implemented           |
 //! | `ttf`               | Enable SDL_ttf font/text rendering APIs                                | Implemented           |
 //! | `hidapi`            | Use SDL's hidapi backend for sensors and controllers                   | Implemented           |

--- a/src/sdl3/mixer/audio.rs
+++ b/src/sdl3/mixer/audio.rs
@@ -1,0 +1,75 @@
+use std::marker::PhantomData;
+
+use crate::{get_error, Error};
+use sdl3_sys::audio::SDL_AudioSpec;
+use sdl3_sys::stdinc::Sint64;
+
+use super::sys;
+
+/// Loaded audio data that can be assigned to tracks for playback.
+///
+/// Audio objects are independent of any particular mixer — they can be shared
+/// across multiple tracks and even multiple mixers. The C library internally
+/// reference-counts audio data assigned to tracks, so it's safe to drop an
+/// `Audio` while tracks still reference it.
+pub struct Audio {
+    raw: *mut sys::MIX_Audio,
+    _marker: PhantomData<*mut ()>, // !Send + !Sync
+}
+
+impl Audio {
+    pub(crate) fn from_raw(raw: *mut sys::MIX_Audio) -> Self {
+        Audio {
+            raw,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get a pointer to the underlying `MIX_Audio`.
+    #[inline]
+    pub fn raw(&self) -> *mut sys::MIX_Audio {
+        self.raw
+    }
+
+    /// Get the total duration of this audio in sample frames.
+    ///
+    /// Returns a negative value if the duration is unknown or infinite.
+    #[doc(alias = "MIX_GetAudioDuration")]
+    pub fn duration(&self) -> i64 {
+        unsafe { sys::MIX_GetAudioDuration(self.raw) as i64 }
+    }
+
+    /// Get the audio format of this audio data.
+    #[doc(alias = "MIX_GetAudioFormat")]
+    pub fn format(&self) -> Result<SDL_AudioSpec, Error> {
+        let mut spec = SDL_AudioSpec {
+            format: sdl3_sys::audio::SDL_AudioFormat::default(),
+            channels: 0,
+            freq: 0,
+        };
+        let ok = unsafe { sys::MIX_GetAudioFormat(self.raw, &mut spec) };
+        if ok {
+            Ok(spec)
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Convert milliseconds to sample frames for this audio.
+    #[doc(alias = "MIX_AudioMSToFrames")]
+    pub fn ms_to_frames(&self, ms: i64) -> i64 {
+        unsafe { sys::MIX_AudioMSToFrames(self.raw, ms as Sint64) as i64 }
+    }
+
+    /// Convert sample frames to milliseconds for this audio.
+    #[doc(alias = "MIX_AudioFramesToMS")]
+    pub fn frames_to_ms(&self, frames: i64) -> i64 {
+        unsafe { sys::MIX_AudioFramesToMS(self.raw, frames as Sint64) as i64 }
+    }
+}
+
+impl Drop for Audio {
+    fn drop(&mut self) {
+        unsafe { sys::MIX_DestroyAudio(self.raw) };
+    }
+}

--- a/src/sdl3/mixer/device.rs
+++ b/src/sdl3/mixer/device.rs
@@ -10,7 +10,7 @@ use sdl3_sys::stdinc::Sint64;
 use super::audio::Audio;
 use super::group::Group;
 use super::track::Track;
-use super::{sys, MixerContext};
+use super::{bool_result, sys, MixerContext};
 
 /// A mixer device that plays sound to an audio device.
 ///
@@ -80,12 +80,7 @@ impl Mixer {
     /// A gain of 0.0 is silence, 1.0 is unchanged, >1.0 amplifies.
     #[doc(alias = "MIX_SetMixerGain")]
     pub fn set_gain(&self, gain: f32) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetMixerGain(self.raw, gain) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetMixerGain(self.raw, gain) })
     }
 
     /// Get the master gain (volume) for the entire mix.
@@ -161,81 +156,46 @@ impl Mixer {
     /// when done.
     #[doc(alias = "MIX_PlayAudio")]
     pub fn play_audio(&self, audio: &Audio) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_PlayAudio(self.raw, audio.raw()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_PlayAudio(self.raw, audio.raw()) })
     }
 
     /// Stop all tracks on this mixer, with optional fade-out in milliseconds.
     #[doc(alias = "MIX_StopAllTracks")]
     pub fn stop_all(&self, fade_out_ms: i64) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_StopAllTracks(self.raw, fade_out_ms as Sint64) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_StopAllTracks(self.raw, fade_out_ms as Sint64) })
     }
 
     /// Pause all tracks on this mixer.
     #[doc(alias = "MIX_PauseAllTracks")]
     pub fn pause_all(&self) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_PauseAllTracks(self.raw) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_PauseAllTracks(self.raw) })
     }
 
     /// Resume all paused tracks on this mixer.
     #[doc(alias = "MIX_ResumeAllTracks")]
     pub fn resume_all(&self) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_ResumeAllTracks(self.raw) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_ResumeAllTracks(self.raw) })
     }
 
     /// Stop all tracks with a specific tag, with optional fade-out in milliseconds.
     #[doc(alias = "MIX_StopTag")]
     pub fn stop_tag(&self, tag: &str, fade_out_ms: i64) -> Result<(), Error> {
         let c_tag = CString::new(tag).unwrap();
-        let ok = unsafe { sys::MIX_StopTag(self.raw, c_tag.as_ptr(), fade_out_ms as Sint64) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_StopTag(self.raw, c_tag.as_ptr(), fade_out_ms as Sint64) })
     }
 
     /// Pause all tracks with a specific tag.
     #[doc(alias = "MIX_PauseTag")]
     pub fn pause_tag(&self, tag: &str) -> Result<(), Error> {
         let c_tag = CString::new(tag).unwrap();
-        let ok = unsafe { sys::MIX_PauseTag(self.raw, c_tag.as_ptr()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_PauseTag(self.raw, c_tag.as_ptr()) })
     }
 
     /// Resume all tracks with a specific tag.
     #[doc(alias = "MIX_ResumeTag")]
     pub fn resume_tag(&self, tag: &str) -> Result<(), Error> {
         let c_tag = CString::new(tag).unwrap();
-        let ok = unsafe { sys::MIX_ResumeTag(self.raw, c_tag.as_ptr()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_ResumeTag(self.raw, c_tag.as_ptr()) })
     }
 }
 

--- a/src/sdl3/mixer/device.rs
+++ b/src/sdl3/mixer/device.rs
@@ -1,0 +1,257 @@
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::ptr;
+
+use crate::{get_error, Error};
+use sdl3_sys::audio::{SDL_AudioDeviceID, SDL_AudioSpec, SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK};
+use sdl3_sys::stdinc::Sint64;
+
+use super::audio::Audio;
+use super::group::Group;
+use super::track::Track;
+use super::{sys, MixerContext};
+
+/// A mixer device that plays sound to an audio device.
+///
+/// This is the main entry point for SDL3_mixer. Create a `Mixer` to open an
+/// audio device, then load audio and create tracks to play sounds.
+pub struct Mixer {
+    raw: *mut sys::MIX_Mixer,
+    _context: MixerContext,
+    _marker: PhantomData<*mut ()>, // !Send + !Sync
+}
+
+impl Mixer {
+    /// Create a mixer that plays to the default audio device.
+    ///
+    /// Pass `None` for `spec` to let SDL choose the best format.
+    #[doc(alias = "MIX_CreateMixerDevice")]
+    pub fn open_device(spec: Option<&SDL_AudioSpec>) -> Result<Mixer, Error> {
+        Self::open_device_id(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, spec)
+    }
+
+    /// Create a mixer that plays to a specific audio device.
+    #[doc(alias = "MIX_CreateMixerDevice")]
+    pub fn open_device_id(
+        device_id: SDL_AudioDeviceID,
+        spec: Option<&SDL_AudioSpec>,
+    ) -> Result<Mixer, Error> {
+        let context = MixerContext::new()?;
+        let spec_ptr = spec
+            .map(|s| s as *const SDL_AudioSpec)
+            .unwrap_or(ptr::null());
+        let raw = unsafe { sys::MIX_CreateMixerDevice(device_id, spec_ptr) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Mixer {
+                raw,
+                _context: context,
+                _marker: PhantomData,
+            })
+        }
+    }
+
+    /// Get a pointer to the underlying `MIX_Mixer`.
+    #[inline]
+    pub fn raw(&self) -> *mut sys::MIX_Mixer {
+        self.raw
+    }
+
+    /// Get the actual audio format in use by this mixer.
+    #[doc(alias = "MIX_GetMixerFormat")]
+    pub fn format(&self) -> Result<SDL_AudioSpec, Error> {
+        let mut spec = SDL_AudioSpec {
+            format: sdl3_sys::audio::SDL_AudioFormat::default(),
+            channels: 0,
+            freq: 0,
+        };
+        let ok = unsafe { sys::MIX_GetMixerFormat(self.raw, &mut spec) };
+        if ok {
+            Ok(spec)
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Set the master gain (volume) for the entire mix.
+    ///
+    /// A gain of 0.0 is silence, 1.0 is unchanged, >1.0 amplifies.
+    #[doc(alias = "MIX_SetMixerGain")]
+    pub fn set_gain(&self, gain: f32) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetMixerGain(self.raw, gain) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Get the master gain (volume) for the entire mix.
+    #[doc(alias = "MIX_GetMixerGain")]
+    pub fn gain(&self) -> f32 {
+        unsafe { sys::MIX_GetMixerGain(self.raw) }
+    }
+
+    /// Lock the mixer for thread-safe access.
+    ///
+    /// Returns an RAII guard that unlocks on drop.
+    #[doc(alias = "MIX_LockMixer")]
+    pub fn lock(&self) -> MixerLock<'_> {
+        unsafe { sys::MIX_LockMixer(self.raw) };
+        MixerLock { mixer: self }
+    }
+
+    /// Create a new track on this mixer.
+    #[doc(alias = "MIX_CreateTrack")]
+    pub fn create_track(&self) -> Result<Track<'_>, Error> {
+        let raw = unsafe { sys::MIX_CreateTrack(self.raw) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Track::from_raw(raw))
+        }
+    }
+
+    /// Create a new group on this mixer.
+    #[doc(alias = "MIX_CreateGroup")]
+    pub fn create_group(&self) -> Result<Group<'_>, Error> {
+        let raw = unsafe { sys::MIX_CreateGroup(self.raw) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Group::from_raw(raw))
+        }
+    }
+
+    /// Load audio from a file path.
+    ///
+    /// If `predecode` is true, the audio will be fully decompressed into memory.
+    /// Otherwise it will be decoded on the fly during playback.
+    #[doc(alias = "MIX_LoadAudio")]
+    pub fn load_audio<P: AsRef<Path>>(&self, path: P, predecode: bool) -> Result<Audio, Error> {
+        let c_path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+        let raw = unsafe { sys::MIX_LoadAudio(self.raw, c_path.as_ptr(), predecode) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Audio::from_raw(raw))
+        }
+    }
+
+    /// Create a sine wave audio source for testing or debugging.
+    ///
+    /// - `hz`: frequency of the sine wave in Hz
+    /// - `amplitude`: volume from 0.0 (silent) to 1.0 (loud)
+    /// - `ms`: duration in milliseconds, or negative for infinite
+    #[doc(alias = "MIX_CreateSineWaveAudio")]
+    pub fn create_sine_wave(&self, hz: i32, amplitude: f32, ms: i64) -> Result<Audio, Error> {
+        let raw = unsafe { sys::MIX_CreateSineWaveAudio(self.raw, hz, amplitude, ms as Sint64) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Audio::from_raw(raw))
+        }
+    }
+
+    /// Play audio once from start to finish without any management ("fire and forget").
+    ///
+    /// Internally, SDL_mixer creates a temporary track, plays it, and cleans up
+    /// when done.
+    #[doc(alias = "MIX_PlayAudio")]
+    pub fn play_audio(&self, audio: &Audio) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_PlayAudio(self.raw, audio.raw()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Stop all tracks on this mixer, with optional fade-out in milliseconds.
+    #[doc(alias = "MIX_StopAllTracks")]
+    pub fn stop_all(&self, fade_out_ms: i64) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_StopAllTracks(self.raw, fade_out_ms as Sint64) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Pause all tracks on this mixer.
+    #[doc(alias = "MIX_PauseAllTracks")]
+    pub fn pause_all(&self) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_PauseAllTracks(self.raw) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Resume all paused tracks on this mixer.
+    #[doc(alias = "MIX_ResumeAllTracks")]
+    pub fn resume_all(&self) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_ResumeAllTracks(self.raw) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Stop all tracks with a specific tag, with optional fade-out in milliseconds.
+    #[doc(alias = "MIX_StopTag")]
+    pub fn stop_tag(&self, tag: &str, fade_out_ms: i64) -> Result<(), Error> {
+        let c_tag = CString::new(tag).unwrap();
+        let ok = unsafe { sys::MIX_StopTag(self.raw, c_tag.as_ptr(), fade_out_ms as Sint64) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Pause all tracks with a specific tag.
+    #[doc(alias = "MIX_PauseTag")]
+    pub fn pause_tag(&self, tag: &str) -> Result<(), Error> {
+        let c_tag = CString::new(tag).unwrap();
+        let ok = unsafe { sys::MIX_PauseTag(self.raw, c_tag.as_ptr()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Resume all tracks with a specific tag.
+    #[doc(alias = "MIX_ResumeTag")]
+    pub fn resume_tag(&self, tag: &str) -> Result<(), Error> {
+        let c_tag = CString::new(tag).unwrap();
+        let ok = unsafe { sys::MIX_ResumeTag(self.raw, c_tag.as_ptr()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+}
+
+impl Drop for Mixer {
+    fn drop(&mut self) {
+        unsafe { sys::MIX_DestroyMixer(self.raw) };
+    }
+}
+
+/// RAII guard for a locked mixer. Unlocks on drop.
+pub struct MixerLock<'a> {
+    mixer: &'a Mixer,
+}
+
+impl Drop for MixerLock<'_> {
+    fn drop(&mut self) {
+        unsafe { sys::MIX_UnlockMixer(self.mixer.raw) };
+    }
+}

--- a/src/sdl3/mixer/device.rs
+++ b/src/sdl3/mixer/device.rs
@@ -1,4 +1,3 @@
-use std::ffi::CString;
 use std::marker::PhantomData;
 use std::path::Path;
 use std::ptr;
@@ -10,7 +9,7 @@ use sdl3_sys::stdinc::Sint64;
 use super::audio::Audio;
 use super::group::Group;
 use super::track::Track;
-use super::{bool_result, sys, MixerContext};
+use super::{bool_result, sys, to_cstring, MixerContext};
 
 /// A mixer device that plays sound to an audio device.
 ///
@@ -126,7 +125,11 @@ impl Mixer {
     /// Otherwise it will be decoded on the fly during playback.
     #[doc(alias = "MIX_LoadAudio")]
     pub fn load_audio<P: AsRef<Path>>(&self, path: P, predecode: bool) -> Result<Audio, Error> {
-        let c_path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+        let path_str = path
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| Error("path contains invalid UTF-8".into()))?;
+        let c_path = to_cstring(path_str)?;
         let raw = unsafe { sys::MIX_LoadAudio(self.raw, c_path.as_ptr(), predecode) };
         if raw.is_null() {
             Err(get_error())
@@ -180,21 +183,21 @@ impl Mixer {
     /// Stop all tracks with a specific tag, with optional fade-out in milliseconds.
     #[doc(alias = "MIX_StopTag")]
     pub fn stop_tag(&self, tag: &str, fade_out_ms: i64) -> Result<(), Error> {
-        let c_tag = CString::new(tag).unwrap();
+        let c_tag = to_cstring(tag)?;
         bool_result(unsafe { sys::MIX_StopTag(self.raw, c_tag.as_ptr(), fade_out_ms as Sint64) })
     }
 
     /// Pause all tracks with a specific tag.
     #[doc(alias = "MIX_PauseTag")]
     pub fn pause_tag(&self, tag: &str) -> Result<(), Error> {
-        let c_tag = CString::new(tag).unwrap();
+        let c_tag = to_cstring(tag)?;
         bool_result(unsafe { sys::MIX_PauseTag(self.raw, c_tag.as_ptr()) })
     }
 
     /// Resume all tracks with a specific tag.
     #[doc(alias = "MIX_ResumeTag")]
     pub fn resume_tag(&self, tag: &str) -> Result<(), Error> {
-        let c_tag = CString::new(tag).unwrap();
+        let c_tag = to_cstring(tag)?;
         bool_result(unsafe { sys::MIX_ResumeTag(self.raw, c_tag.as_ptr()) })
     }
 }

--- a/src/sdl3/mixer/group.rs
+++ b/src/sdl3/mixer/group.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
-use crate::{get_error, Error};
+use crate::Error;
 
 use super::device::Mixer;
-use super::sys;
 use super::track::Track;
+use super::{bool_result, sys};
 
 /// A group for organizing tracks.
 ///
@@ -39,23 +39,13 @@ impl<'mixer> Group<'mixer> {
     /// removes it from its previous group.
     #[doc(alias = "MIX_SetTrackGroup")]
     pub fn assign_track(&self, track: &Track) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackGroup(track.raw(), self.raw) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackGroup(track.raw(), self.raw) })
     }
 
-    /// Remove a track from this group (return it to the default group).
+    /// Remove a track from any group (return it to the default group).
     #[doc(alias = "MIX_SetTrackGroup")]
     pub fn remove_track(&self, track: &Track) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackGroup(track.raw(), std::ptr::null_mut()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackGroup(track.raw(), std::ptr::null_mut()) })
     }
 }
 

--- a/src/sdl3/mixer/group.rs
+++ b/src/sdl3/mixer/group.rs
@@ -1,0 +1,66 @@
+use std::marker::PhantomData;
+
+use crate::{get_error, Error};
+
+use super::device::Mixer;
+use super::sys;
+use super::track::Track;
+
+/// A group for organizing tracks.
+///
+/// Groups allow you to receive post-mix callbacks for a subset of tracks,
+/// which is useful for applying effects or level metering to specific
+/// categories of sound (e.g., music vs. sound effects).
+///
+/// A group must not outlive its parent mixer (enforced by the lifetime
+/// parameter).
+pub struct Group<'mixer> {
+    raw: *mut sys::MIX_Group,
+    _marker: PhantomData<&'mixer Mixer>,
+}
+
+impl<'mixer> Group<'mixer> {
+    pub(crate) fn from_raw(raw: *mut sys::MIX_Group) -> Self {
+        Group {
+            raw,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get a pointer to the underlying `MIX_Group`.
+    #[inline]
+    pub fn raw(&self) -> *mut sys::MIX_Group {
+        self.raw
+    }
+
+    /// Assign a track to this group.
+    ///
+    /// A track can only belong to one group at a time. Assigning to a new group
+    /// removes it from its previous group.
+    #[doc(alias = "MIX_SetTrackGroup")]
+    pub fn assign_track(&self, track: &Track) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackGroup(track.raw(), self.raw) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Remove a track from this group (return it to the default group).
+    #[doc(alias = "MIX_SetTrackGroup")]
+    pub fn remove_track(&self, track: &Track) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackGroup(track.raw(), std::ptr::null_mut()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+}
+
+impl Drop for Group<'_> {
+    fn drop(&mut self) {
+        unsafe { sys::MIX_DestroyGroup(self.raw) };
+    }
+}

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -37,34 +37,40 @@ pub use self::track::{Point3D, StereoGains, Track};
 
 use crate::{get_error, Error};
 use std::ffi::CStr;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::marker::PhantomData;
 
 /// A context manager for `SDL3_mixer` to manage library init and quit.
 ///
 /// SDL3_mixer is reference-counted internally, so multiple contexts can exist.
-/// The library is only deinitialized when the last context is dropped.
+/// The library is only deinitialized when `MIX_Quit()` has been called a
+/// matching number of times.
+///
+/// `MIX_Init` and `MIX_Quit` are not thread-safe, so this type is `!Send`
+/// and `!Sync`.
 #[must_use]
-pub struct MixerContext;
-
-static MIXER_COUNT: AtomicU32 = AtomicU32::new(0);
+pub struct MixerContext {
+    _marker: PhantomData<*mut ()>, // !Send + !Sync
+}
 
 impl Clone for MixerContext {
     fn clone(&self) -> Self {
-        MIXER_COUNT.fetch_add(1, Ordering::Relaxed);
-        MixerContext
+        // MIX_Init is safe to call multiple times; the C library ref-counts internally.
+        unsafe { sys::MIX_Init() };
+        MixerContext {
+            _marker: PhantomData,
+        }
     }
 }
 
 impl MixerContext {
     fn new() -> Result<Self, Error> {
-        if MIXER_COUNT.fetch_add(1, Ordering::Relaxed) == 0 {
-            let result = unsafe { sys::MIX_Init() };
-            if !result {
-                MIXER_COUNT.store(0, Ordering::Relaxed);
-                return Err(get_error());
-            }
+        let result = unsafe { sys::MIX_Init() };
+        if !result {
+            return Err(get_error());
         }
-        Ok(Self)
+        Ok(MixerContext {
+            _marker: PhantomData,
+        })
     }
 }
 
@@ -79,13 +85,7 @@ fn bool_result(ok: bool) -> Result<(), Error> {
 
 impl Drop for MixerContext {
     fn drop(&mut self) {
-        let prev_count = MIXER_COUNT.fetch_sub(1, Ordering::Relaxed);
-        assert!(prev_count > 0);
-        if prev_count == 1 {
-            unsafe {
-                sys::MIX_Quit();
-            }
-        }
+        unsafe { sys::MIX_Quit() };
     }
 }
 

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -36,7 +36,7 @@ pub use self::group::Group;
 pub use self::track::{Point3D, StereoGains, Track};
 
 use crate::{get_error, Error};
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 
 /// A context manager for `SDL3_mixer` to manage library init and quit.
@@ -55,7 +55,12 @@ pub struct MixerContext {
 impl Clone for MixerContext {
     fn clone(&self) -> Self {
         // MIX_Init is safe to call multiple times; the C library ref-counts internally.
-        unsafe { sys::MIX_Init() };
+        // After the first successful init, subsequent calls always succeed.
+        let ok = unsafe { sys::MIX_Init() };
+        assert!(
+            ok,
+            "MIX_Init failed during clone: this should not happen after initial init succeeded"
+        );
         MixerContext {
             _marker: PhantomData,
         }
@@ -81,6 +86,11 @@ fn bool_result(ok: bool) -> Result<(), Error> {
     } else {
         Err(get_error())
     }
+}
+
+/// Create a CString from a &str, returning an Error on invalid input.
+fn to_cstring(s: &str) -> Result<CString, Error> {
+    CString::new(s).map_err(|e| Error(e.to_string()))
 }
 
 impl Drop for MixerContext {

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -1,1011 +1,116 @@
 //!
-//! Bindings for the `SDL_mixer` extension library.
+//! Bindings for the `SDL3_mixer` extension library.
 //!
-//! SDL3_mixer has not been released yet, so the `mixer` Cargo feature is kept
-//! disabled to avoid build breakage. The module remains in-tree so we can re-enable
-//! it as soon as an upstream `sdl3-mixer-sys` crate becomes available.
+//! SDL3_mixer provides audio mixing, playback, and effects for SDL3-based
+//! applications. It supports loading many audio formats (WAV, MP3, OGG, FLAC,
+//! etc.), mixing multiple sounds simultaneously, basic 3D positional audio,
+//! and various audio effects.
 //!
-//!
-//! Note that you need to build with the
-//! feature `mixer` for this module to be enabled,
-//! like so:
+//! Note that you need to build with the `mixer` feature for this module to be
+//! enabled:
 //!
 //! ```bash
 //! $ cargo build --features "mixer"
 //! ```
 //!
-//! If you want to use this with from inside your own
-//! crate, you will need to add this in your Cargo.toml
+//! If you want to use this from inside your own crate, add this to your
+//! Cargo.toml:
 //!
 //! ```toml
 //! [dependencies.sdl3]
-//! version = ...
+//! version = "..."
 //! default-features = false
 //! features = ["mixer"]
 //! ```
 
-use audio::AudioFormatNum;
-use get_error;
-use iostream::IOStream;
-use libc::c_void;
-use libc::{c_double, c_int, c_uint};
-use std::borrow::ToOwned;
-use std::convert::TryInto;
-use std::default;
-use std::ffi::{CStr, CString};
-use std::fmt;
-use std::marker::PhantomData;
-use std::path::Path;
-use std::str::from_utf8;
-use sys;
-use sys::mixer;
-use version::Version;
+mod audio;
+mod device;
+mod group;
+mod track;
 
-// This comes from SDL_audio.h
-#[allow(non_camel_case_types)]
-mod ll {
-    pub const AUDIO_U8: u16 = 0x0008;
-    pub const AUDIO_S8: u16 = 0x8008;
-    pub const AUDIO_U16LSB: u16 = 0x0010;
-    pub const AUDIO_S16LSB: u16 = 0x8010;
-    pub const AUDIO_U16MSB: u16 = 0x1010;
-    pub const AUDIO_S16MSB: u16 = 0x9010;
-    pub const AUDIO_U16: u16 = AUDIO_U16LSB;
-    pub const AUDIO_S16: u16 = AUDIO_S16LSB;
-    pub const AUDIO_S32LSB: u16 = 0x8020;
-    pub const AUDIO_S32MSB: u16 = 0x9020;
-    pub const AUDIO_S32: u16 = AUDIO_S32LSB;
-    pub const AUDIO_F32LSB: u16 = 0x8120;
-    pub const AUDIO_F32MSB: u16 = 0x9120;
-    pub const AUDIO_F32: u16 = AUDIO_F32LSB;
-    pub const AUDIO_U16SYS: u16 = AUDIO_U16LSB;
-    pub const AUDIO_S16SYS: u16 = AUDIO_S16LSB;
-    pub const AUDIO_S32SYS: u16 = AUDIO_S32LSB;
-    pub const AUDIO_F32SYS: u16 = AUDIO_F32LSB;
-}
+pub use sdl3_mixer_sys::mixer as sys;
 
-pub type AudioFormat = u16;
+pub use self::audio::Audio;
+pub use self::device::{Mixer, MixerLock};
+pub use self::group::Group;
+pub use self::track::{Point3D, StereoGains, Track};
 
-pub const AUDIO_U8: AudioFormat = ll::AUDIO_U8;
-pub const AUDIO_S8: AudioFormat = ll::AUDIO_S8;
-pub const AUDIO_U16LSB: AudioFormat = ll::AUDIO_U16LSB;
-pub const AUDIO_S16LSB: AudioFormat = ll::AUDIO_S16LSB;
-pub const AUDIO_U16MSB: AudioFormat = ll::AUDIO_U16MSB;
-pub const AUDIO_S16MSB: AudioFormat = ll::AUDIO_S16MSB;
-pub const AUDIO_U16: AudioFormat = ll::AUDIO_U16;
-pub const AUDIO_S16: AudioFormat = ll::AUDIO_S16;
-pub const AUDIO_S32LSB: AudioFormat = ll::AUDIO_S32LSB;
-pub const AUDIO_S32MSB: AudioFormat = ll::AUDIO_S32MSB;
-pub const AUDIO_S32: AudioFormat = ll::AUDIO_S32;
-pub const AUDIO_F32LSB: AudioFormat = ll::AUDIO_F32LSB;
-pub const AUDIO_F32MSB: AudioFormat = ll::AUDIO_F32MSB;
-pub const AUDIO_F32: AudioFormat = ll::AUDIO_F32;
-pub const AUDIO_U16SYS: AudioFormat = ll::AUDIO_U16SYS;
-pub const AUDIO_S16SYS: AudioFormat = ll::AUDIO_S16SYS;
-pub const AUDIO_S32SYS: AudioFormat = ll::AUDIO_S32SYS;
-pub const AUDIO_F32SYS: AudioFormat = ll::AUDIO_F32SYS;
+use crate::{get_error, Error};
+use std::ffi::CStr;
+use std::sync::atomic::{AtomicU32, Ordering};
 
-/// The suggested default is signed 16bit samples in host byte order.
-pub const DEFAULT_FORMAT: AudioFormat = ll::AUDIO_S16SYS;
-/// Default channels: Stereo.
-pub const DEFAULT_CHANNELS: i32 = 2;
-/// Good default sample rate in Hz (samples per second) for PC sound cards.
-pub const DEFAULT_FREQUENCY: i32 = 22_050;
-/// Maximum value for any volume setting.
-pub const MAX_VOLUME: i32 = 128;
-
-/// Returns the version of the dynamically linked `SDL_mixer` library
-pub fn get_linked_version() -> Version {
-    unsafe { Version::from_ll(*mixer::Mix_Linked_Version()) }
-}
-
-bitflags!(
-    pub struct InitFlag : u32 {
-        const FLAC = mixer::MIX_InitFlags_MIX_INIT_FLAC as u32;
-        const MOD  = mixer::MIX_InitFlags_MIX_INIT_MOD as u32;
-        const MP3  = mixer::MIX_InitFlags_MIX_INIT_MP3 as u32;
-        const OGG  = mixer::MIX_InitFlags_MIX_INIT_OGG as u32;
-        const MID  = mixer::MIX_InitFlags_MIX_INIT_MID as u32;
-        const OPUS = mixer::MIX_InitFlags_MIX_INIT_OPUS as u32;
-    }
-);
-
-impl ToString for InitFlag {
-    fn to_string(&self) -> String {
-        let mut string = "".to_string();
-        if self.contains(InitFlag::FLAC) {
-            string = string + &"INIT_FLAC ".to_string();
-        }
-        if self.contains(InitFlag::MOD) {
-            string = string + &"INIT_MOD ".to_string();
-        }
-        if self.contains(InitFlag::MP3) {
-            string = string + &"INIT_MP3 ".to_string();
-        }
-        if self.contains(InitFlag::OGG) {
-            string = string + &"INIT_OGG ".to_string();
-        }
-        if self.contains(InitFlag::MID) {
-            string = string + &"INIT_MID ".to_string();
-        }
-        if self.contains(InitFlag::OPUS) {
-            string = string + &"INIT_OPUS ".to_string();
-        }
-        string
-    }
-}
-
-/// Context manager for `SDL_mixer` to manage init and quit
-pub struct Sdl2MixerContext;
-
-/// Cleans up all dynamically loaded library handles, freeing memory.
-impl Drop for Sdl2MixerContext {
-    fn drop(&mut self) {
-        unsafe {
-            mixer::Mix_Quit();
-        }
-    }
-}
-
-/// Loads dynamic libraries and prepares them for use.  Flags should be one or
-/// more flags from `InitFlag`. Returns error if any of the requested flags
-/// failed
-pub fn init(flags: InitFlag) -> Result<Sdl2MixerContext, String> {
-    let return_flags = unsafe {
-        let ret = mixer::Mix_Init(flags.bits() as c_int);
-        InitFlag::from_bits_truncate(ret as u32)
-    };
-
-    if return_flags & flags != flags {
-        // According to docs, error message text is not always set
-        let mut error = get_error();
-        if error.is_empty() {
-            let failed_libs = flags - return_flags;
-            error = format!("Could not init: {}", failed_libs);
-            let _ = ::set_error(&error);
-        }
-        Err(error)
-    } else {
-        Ok(Sdl2MixerContext)
-    }
-}
-
-/// Open the mixer with a certain audio format.
+/// A context manager for `SDL3_mixer` to manage library init and quit.
 ///
-/// * `chunksize`: It is recommended to choose values between 256 and 1024, depending on whether
-///                you prefer latency or compatibility. Small values reduce latency but may not
-///                work very well on older systems. For instance, a chunk size of 256 will give
-///                you a latency of 6ms, while a chunk size of 1024 will give you a latency of 23ms
-///                for a frequency of 44100kHz.
-pub fn open_audio(
-    frequency: i32,
-    format: AudioFormat,
-    channels: i32,
-    chunksize: i32,
-) -> Result<(), String> {
-    let ret = unsafe {
-        mixer::Mix_OpenAudio(
-            frequency as c_int,
-            format,
-            channels as c_int,
-            chunksize as c_int,
-        )
-    };
-    if ret == 0 {
-        Ok(())
-    } else {
-        Err(get_error())
+/// SDL3_mixer is reference-counted internally, so multiple contexts can exist.
+/// The library is only deinitialized when the last context is dropped.
+#[must_use]
+#[derive(Clone)]
+pub struct MixerContext;
+
+static MIXER_COUNT: AtomicU32 = AtomicU32::new(0);
+
+impl MixerContext {
+    fn new() -> Result<Self, Error> {
+        if MIXER_COUNT.fetch_add(1, Ordering::Relaxed) == 0 {
+            let result = unsafe { sys::MIX_Init() };
+            if !result {
+                MIXER_COUNT.store(0, Ordering::Relaxed);
+                return Err(get_error());
+            }
+        }
+        Ok(Self)
     }
 }
 
-/// Shutdown and cleanup the mixer API.
-pub fn close_audio() {
-    unsafe { mixer::Mix_CloseAudio() }
-}
-
-/// Get the actual audio format in use by the opened audio device.
-pub fn query_spec() -> Result<(i32, AudioFormat, i32), String> {
-    let mut frequency: c_int = 0;
-    let mut format: u16 = 0;
-    let mut channels: c_int = 0;
-    let ret = unsafe { mixer::Mix_QuerySpec(&mut frequency, &mut format, &mut channels) };
-    if ret == 0 {
-        Err(get_error())
-    } else {
-        Ok((frequency as i32, format as AudioFormat, channels as i32))
-    }
-}
-
-// 4.2 Samples
-
-/// Get the number of sample chunk decoders available from the `Mix_GetChunkDecoder` function.
-pub fn get_chunk_decoders_number() -> i32 {
-    unsafe { mixer::Mix_GetNumChunkDecoders() as i32 }
-}
-
-/// Get the name of the indexed sample chunk decoder.
-pub fn get_chunk_decoder(index: i32) -> String {
-    unsafe {
-        let name = mixer::Mix_GetChunkDecoder(index as c_int);
-        from_utf8(CStr::from_ptr(name).to_bytes())
-            .unwrap()
-            .to_owned()
-    }
-}
-
-/// The internal format for an audio chunk.
-#[derive(PartialEq)]
-pub struct Chunk {
-    pub raw: *mut mixer::Mix_Chunk,
-    pub owned: bool,
-}
-
-impl Drop for Chunk {
+impl Drop for MixerContext {
     fn drop(&mut self) {
-        if self.owned {
+        let prev_count = MIXER_COUNT.fetch_sub(1, Ordering::Relaxed);
+        assert!(prev_count > 0);
+        if prev_count == 1 {
             unsafe {
-                // Mix_QuickLoad_* functions don't set the allocated flag, but from_raw_buffer
-                // *does* take ownership of the data, so we need to deallocate the buffers here,
-                // because Mix_FreeChunk won't and we'd be leaking memory otherwise.
-                if (*self.raw).allocated == 0 {
-                    drop(Box::from_raw((*self.raw).abuf));
-                }
-                mixer::Mix_FreeChunk(self.raw);
+                sys::MIX_Quit();
             }
         }
     }
 }
 
-impl Chunk {
-    /// Load file for use as a sample.
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Chunk, String> {
-        let raw = unsafe { mixer::Mix_LoadWAV_RW(IOStream::from_file(path, "rb")?.raw(), 0) };
-        Self::from_owned_raw(raw)
-    }
-
-    /// Load chunk from a buffer containing raw audio data in the mixer format. The length of the
-    /// buffer has to fit in 32-bit unsigned integer. The chunk takes ownership of the buffer.
-    ///
-    /// It's your responsibility to provide the audio data in the right format, as no conversion
-    /// will take place when using this method.
-    pub fn from_raw_buffer<T: AudioFormatNum>(buffer: Box<[T]>) -> Result<Chunk, String> {
-        use std::mem::size_of;
-        let len: u32 = (buffer.len() * size_of::<T>()).try_into().unwrap();
-        let raw = unsafe { mixer::Mix_QuickLoad_RAW(Box::into_raw(buffer) as *mut u8, len) };
-        Self::from_owned_raw(raw)
-    }
-
-    fn from_owned_raw(raw: *mut mixer::Mix_Chunk) -> Result<Chunk, String> {
-        if raw.is_null() {
-            Err(get_error())
-        } else {
-            Ok(Chunk {
-                raw: raw,
-                owned: true,
-            })
-        }
-    }
-
-    /// Set chunk->volume to volume.
-    pub fn set_volume(&mut self, volume: i32) -> i32 {
-        unsafe { mixer::Mix_VolumeChunk(self.raw, volume as c_int) as i32 }
-    }
-
-    /// current volume for the chunk.
-    pub fn get_volume(&self) -> i32 {
-        unsafe { mixer::Mix_VolumeChunk(self.raw, -1) as i32 }
-    }
+/// Initialize the SDL3_mixer library and return a context manager.
+///
+/// The context will clean up the library when dropped. Multiple calls are
+/// safe — the library uses internal reference counting.
+#[doc(alias = "MIX_Init")]
+pub fn init() -> Result<MixerContext, Error> {
+    MixerContext::new()
 }
 
-/// Loader trait for `IOStream`
-pub trait LoaderIOStream<'a> {
-    /// Load src for use as a sample.
-    fn load_wav(&self) -> Result<Chunk, String>;
-
-    fn load_music(&'a self) -> Result<Music<'a>, String>;
+/// Get the version of the dynamically linked SDL_mixer library.
+#[doc(alias = "MIX_Version")]
+pub fn get_linked_version() -> i32 {
+    sys::MIX_Version()
 }
 
-impl<'a> LoaderIOStream<'a> for IOStream<'a> {
-    /// Load src for use as a sample.
-    fn load_wav(&self) -> Result<Chunk, String> {
-        let raw = unsafe { mixer::Mix_LoadWAV_RW(self.raw(), 0) };
-        if raw.is_null() {
-            Err(get_error())
-        } else {
-            Ok(Chunk {
-                raw: raw,
-                owned: true,
-            })
-        }
-    }
-
-    /// Load src for use as music.
-    fn load_music(&self) -> Result<Music<'a>, String> {
-        let raw = unsafe { mixer::Mix_LoadMUS_RW(self.raw(), 0) };
-        if raw.is_null() {
-            Err(get_error())
-        } else {
-            Ok(Music {
-                raw: raw,
-                owned: true,
-                _marker: PhantomData,
-            })
-        }
-    }
+/// Get the number of audio decoders available.
+#[doc(alias = "MIX_GetNumAudioDecoders")]
+pub fn get_num_audio_decoders() -> i32 {
+    unsafe { sys::MIX_GetNumAudioDecoders() }
 }
 
-// 4.3 Channels
-
-/// Fader effect type enumerations
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Hash)]
-pub enum Fading {
-    NoFading = mixer::Mix_Fading_MIX_NO_FADING as i32,
-    FadingOut = mixer::Mix_Fading_MIX_FADING_OUT as i32,
-    FadingIn = mixer::Mix_Fading_MIX_FADING_IN as i32,
-}
-
-/// Sound effect channel.
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Channel(pub i32);
-
-/// Set the number of channels being mixed.
-pub fn allocate_channels(numchans: i32) -> i32 {
-    unsafe { mixer::Mix_AllocateChannels(numchans as c_int) as i32 }
-}
-
-static mut CHANNEL_FINISHED_CALLBACK: Option<Box<dyn Fn(Channel) + 'static>> = None;
-
-extern "C" fn c_channel_finished_callback(ch: c_int) {
+/// Get the name of a specific audio decoder by index.
+///
+/// Returns `None` if the index is out of range.
+#[doc(alias = "MIX_GetAudioDecoder")]
+pub fn get_audio_decoder(index: i32) -> Option<String> {
     unsafe {
-        match CHANNEL_FINISHED_CALLBACK {
-            None => (),
-            Some(ref cb) => cb(Channel(ch as i32)),
-        }
-    }
-}
-
-/// When channel playback is halted, then the specified `channel_finished` function is called.
-pub fn set_channel_finished(f: impl Fn(Channel) + 'static) {
-    unsafe {
-        CHANNEL_FINISHED_CALLBACK = Some(Box::new(f));
-        mixer::Mix_ChannelFinished(Some(
-            c_channel_finished_callback as extern "C" fn(ch: c_int),
-        ));
-    }
-}
-
-/// Unhooks the specified function set before, so no function is called when channel playback is
-/// halted.
-pub fn unset_channel_finished() {
-    unsafe {
-        mixer::Mix_ChannelFinished(None);
-        CHANNEL_FINISHED_CALLBACK = None;
-    }
-}
-
-impl Channel {
-    /// Represent for all channels (-1)
-    pub fn all() -> Channel {
-        Channel(-1)
-    }
-
-    /// This is the MIX_CHANNEL_POST (-2)
-    pub fn post() -> Channel {
-        Channel(-2)
-    }
-
-    /// Set the volume for any allocated channel.
-    pub fn set_volume(self, volume: i32) -> i32 {
-        let Channel(ch) = self;
-        unsafe { mixer::Mix_Volume(ch as c_int, volume as c_int) as i32 }
-    }
-
-    /// Returns the channels volume on scale of 0 to 128.
-    pub fn get_volume(self) -> i32 {
-        let Channel(ch) = self;
-        unsafe { mixer::Mix_Volume(ch as c_int, -1) as i32 }
-    }
-
-    /// Play chunk on channel, or if channel is -1, pick the first free unreserved channel.
-    pub fn play(self, chunk: &Chunk, loops: i32) -> Result<Channel, String> {
-        self.play_timed(chunk, loops, -1)
-    }
-
-    pub fn play_timed(self, chunk: &Chunk, loops: i32, ticks: i32) -> Result<Channel, String> {
-        let Channel(ch) = self;
-        let ret = unsafe {
-            mixer::Mix_PlayChannelTimed(ch as c_int, chunk.raw, loops as c_int, ticks as c_int)
-        };
-        if ret == -1 {
-            Err(get_error())
+        let name = sys::MIX_GetAudioDecoder(index);
+        if name.is_null() {
+            None
         } else {
-            Ok(Channel(ret as i32))
-        }
-    }
-
-    /// Play chunk on channel, or if channel is -1, pick the first free unreserved channel.
-    pub fn fade_in(self, chunk: &Chunk, loops: i32, ms: i32) -> Result<Channel, String> {
-        self.fade_in_timed(chunk, loops, ms, -1)
-    }
-
-    pub fn fade_in_timed(
-        self,
-        chunk: &Chunk,
-        loops: i32,
-        ms: i32,
-        ticks: i32,
-    ) -> Result<Channel, String> {
-        let Channel(ch) = self;
-        let ret = unsafe {
-            mixer::Mix_FadeInChannelTimed(
-                ch as c_int,
-                chunk.raw,
-                loops as c_int,
-                ms as c_int,
-                ticks as c_int,
+            Some(
+                CStr::from_ptr(name)
+                    .to_str()
+                    .unwrap_or("(invalid UTF-8)")
+                    .to_owned(),
             )
-        };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(Channel(ret as i32))
-        }
-    }
-
-    /// Pause channel, or all playing channels if -1 is passed in.
-    pub fn pause(self) {
-        let Channel(ch) = self;
-        unsafe {
-            mixer::Mix_Pause(ch as c_int);
-        }
-    }
-
-    /// Unpause channel, or all playing and paused channels if -1 is passed in.
-    pub fn resume(self) {
-        let Channel(ch) = self;
-        unsafe {
-            mixer::Mix_Resume(ch as c_int);
-        }
-    }
-
-    /// Halt channel playback
-    pub fn halt(self) {
-        let Channel(ch) = self;
-        unsafe {
-            mixer::Mix_HaltChannel(ch as c_int);
-        }
-    }
-
-    /// Halt channel playback, after ticks milliseconds.
-    pub fn expire(self, ticks: i32) -> i32 {
-        let Channel(ch) = self;
-        unsafe { mixer::Mix_ExpireChannel(ch as c_int, ticks as c_int) as i32 }
-    }
-
-    /// Gradually fade out which channel over ms milliseconds starting from now.
-    pub fn fade_out(self, ms: i32) -> i32 {
-        let Channel(ch) = self;
-        unsafe { mixer::Mix_FadeOutChannel(ch as c_int, ms as c_int) as i32 }
-    }
-
-    /// if channel is playing, or not.
-    pub fn is_playing(self) -> bool {
-        let Channel(ch) = self;
-        unsafe { mixer::Mix_Playing(ch as c_int) != 0 }
-    }
-
-    ///  if channel is paused, or not.
-    pub fn is_paused(self) -> bool {
-        let Channel(ch) = self;
-        unsafe { mixer::Mix_Paused(ch as c_int) != 0 }
-    }
-
-    /// if channel is fading in, out, or not
-    pub fn get_fading(self) -> Fading {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_FadingChannel(ch as c_int) as c_uint };
-        match ret {
-            mixer::Mix_Fading_MIX_FADING_OUT => Fading::FadingOut,
-            mixer::Mix_Fading_MIX_FADING_IN => Fading::FadingIn,
-            mixer::Mix_Fading_MIX_NO_FADING | _ => Fading::NoFading,
-        }
-    }
-
-    /// Get the most recent sample chunk pointer played on channel.
-    pub fn get_chunk(self) -> Option<Chunk> {
-        let Channel(ch) = self;
-        let raw = unsafe { mixer::Mix_GetChunk(ch as c_int) };
-        if raw.is_null() {
-            None
-        } else {
-            Some(Chunk {
-                raw: raw,
-                owned: false,
-            })
-        }
-    }
-
-    /// This removes all effects registered to channel.
-    pub fn unregister_all_effects(self) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_UnregisterAllEffects(ch as c_int) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Sets a panning effect, where left and right is the volume of the left and right channels.
-    /// They range from 0 (silence) to 255 (loud).
-    pub fn set_panning(self, left: u8, right: u8) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetPanning(ch as c_int, left, right) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Unregisters panning effect.
-    pub fn unset_panning(self) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetPanning(ch as c_int, 255, 255) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// This effect simulates a simple attenuation of volume due to distance.
-    /// distance ranges from 0 (close/loud) to 255 (far/quiet).
-    pub fn set_distance(self, distance: u8) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetDistance(ch as c_int, distance) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Unregisters distance effect.
-    pub fn unset_distance(self) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetDistance(ch as c_int, 0) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// This effect emulates a simple 3D audio effect.
-    /// angle ranges from 0 to 360 degrees going clockwise, where 0 is directly in front.
-    /// distance ranges from 0 (close/loud) to 255 (far/quiet).
-    pub fn set_position(self, angle: i16, distance: u8) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetPosition(ch as c_int, angle, distance) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Unregisters position effect.
-    pub fn unset_position(self) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetPosition(ch as c_int, 0, 0) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Simple reverse stereo, swaps left and right channel sound.
-    /// true for reverse, false to unregister effect.
-    pub fn set_reverse_stereo(self, flip: bool) -> Result<(), String> {
-        let Channel(ch) = self;
-        let ret = unsafe { mixer::Mix_SetReverseStereo(ch as c_int, flip as c_int) };
-        if ret == 0 {
-            Err(get_error())
-        } else {
-            Ok(())
         }
     }
 }
-
-/// Returns how many channels are currently playing.
-pub fn get_playing_channels_number() -> i32 {
-    unsafe { mixer::Mix_Playing(-1) as i32 }
-}
-
-/// Returns how many channels are currently paused.
-pub fn get_paused_channels_number() -> i32 {
-    unsafe { mixer::Mix_Paused(-1) as i32 }
-}
-
-// 4.4 Groups
-
-/// Reserve num channels from being used when playing samples when
-/// passing in -1 as a channel number to playback functions.
-pub fn reserve_channels(num: i32) -> i32 {
-    unsafe { mixer::Mix_ReserveChannels(num as c_int) as i32 }
-}
-
-/// Sound effect channel grouping.
-#[derive(Copy, Clone)]
-pub struct Group(pub i32);
-
-impl default::Default for Group {
-    fn default() -> Group {
-        Group(-1)
-    }
-}
-
-impl Group {
-    /// Add channels starting at from up through to to group tag,
-    /// or reset it's group to the default group tag (-1).
-    pub fn add_channels_range(self, from: i32, to: i32) -> i32 {
-        let Group(g) = self;
-        unsafe { mixer::Mix_GroupChannels(from as c_int, to as c_int, g as c_int) as i32 }
-    }
-
-    /// Add which channel to group tag, or reset it's group to the default group tag
-    pub fn add_channel(self, Channel(ch): Channel) -> bool {
-        let Group(g) = self;
-        unsafe { mixer::Mix_GroupChannel(ch as c_int, g as c_int) == 1 }
-    }
-
-    /// Count the number of channels in group
-    pub fn count(self) -> i32 {
-        let Group(g) = self;
-        unsafe { mixer::Mix_GroupCount(g as c_int) as i32 }
-    }
-
-    /// Find the first available (not playing) channel in group
-    pub fn find_available(self) -> Option<Channel> {
-        let Group(g) = self;
-        let ret = unsafe { mixer::Mix_GroupAvailable(g as c_int) as i32 };
-        if ret == -1 {
-            None
-        } else {
-            Some(Channel(ret))
-        }
-    }
-
-    /// Find the oldest actively playing channel in group
-    pub fn find_oldest(self) -> Option<Channel> {
-        let Group(g) = self;
-        let ret = unsafe { mixer::Mix_GroupOldest(g as c_int) as i32 };
-        if ret == -1 {
-            None
-        } else {
-            Some(Channel(ret))
-        }
-    }
-
-    /// Find the newest, most recently started, actively playing channel in group.
-    pub fn find_newest(self) -> Option<Channel> {
-        let Group(g) = self;
-        let ret = unsafe { mixer::Mix_GroupNewer(g as c_int) as i32 };
-        if ret == -1 {
-            None
-        } else {
-            Some(Channel(ret))
-        }
-    }
-
-    /// Gradually fade out channels in group over some milliseconds starting from now.
-    /// Returns the number of channels set to fade out.
-    pub fn fade_out(self, ms: i32) -> i32 {
-        let Group(g) = self;
-        unsafe { mixer::Mix_FadeOutGroup(g as c_int, ms as c_int) as i32 }
-    }
-
-    /// Halt playback on all channels in group.
-    pub fn halt(self) {
-        let Group(g) = self;
-        unsafe {
-            mixer::Mix_HaltGroup(g as c_int);
-        }
-    }
-}
-
-// 4.5 Music
-
-/// Get the number of music decoders available.
-pub fn get_music_decoders_number() -> i32 {
-    unsafe { mixer::Mix_GetNumMusicDecoders() as i32 }
-}
-
-/// Get the name of the indexed music decoder.
-pub fn get_music_decoder(index: i32) -> String {
-    unsafe {
-        let name = mixer::Mix_GetMusicDecoder(index as c_int);
-        from_utf8(CStr::from_ptr(name).to_bytes())
-            .unwrap()
-            .to_owned()
-    }
-}
-
-/// Music type enumerations
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq, Hash, Debug)]
-pub enum MusicType {
-    MusicNone = mixer::Mix_MusicType_MUS_NONE as i32,
-    MusicCmd = mixer::Mix_MusicType_MUS_CMD as i32,
-    MusicWav = mixer::Mix_MusicType_MUS_WAV as i32,
-    MusicMod = mixer::Mix_MusicType_MUS_MOD as i32,
-    MusicMid = mixer::Mix_MusicType_MUS_MID as i32,
-    MusicOgg = mixer::Mix_MusicType_MUS_OGG as i32,
-    MusicMp3 = mixer::Mix_MusicType_MUS_MP3 as i32,
-    MusicMp3Mad = mixer::Mix_MusicType_MUS_MP3_MAD_UNUSED as i32,
-    MusicFlac = mixer::Mix_MusicType_MUS_FLAC as i32,
-    MusicModPlug = mixer::Mix_MusicType_MUS_MODPLUG_UNUSED as i32,
-}
-
-// hooks
-static mut MUSIC_FINISHED_HOOK: Option<fn()> = None;
-
-extern "C" fn c_music_finished_hook() {
-    unsafe {
-        match MUSIC_FINISHED_HOOK {
-            None => (),
-            Some(f) => f(),
-        }
-    }
-}
-
-/// This is an opaque data type used for Music data.
-#[derive(PartialEq)]
-pub struct Music<'a> {
-    pub raw: *mut mixer::Mix_Music,
-    pub owned: bool,
-    _marker: PhantomData<&'a ()>,
-}
-
-impl<'a> Drop for Music<'a> {
-    fn drop(&mut self) {
-        if self.owned {
-            unsafe { mixer::Mix_FreeMusic(self.raw) };
-        }
-    }
-}
-
-impl<'a> fmt::Debug for Music<'a> {
-    /// Shows the original regular expression.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "<Music>")
-    }
-}
-
-impl<'a> Music<'a> {
-    /// Load music file to use.
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Music<'static>, String> {
-        let raw = unsafe {
-            let c_path = CString::new(path.as_ref().to_str().unwrap()).unwrap();
-            mixer::Mix_LoadMUS(c_path.as_ptr())
-        };
-        if raw.is_null() {
-            Err(get_error())
-        } else {
-            Ok(Music {
-                raw: raw,
-                owned: true,
-                _marker: PhantomData,
-            })
-        }
-    }
-
-    /// Load music from a static byte buffer.
-    #[doc(alias = "SDL_RWFromConstMem")]
-    pub fn from_static_bytes(buf: &'static [u8]) -> Result<Music<'static>, String> {
-        let rw = unsafe {
-            sys::SDL_RWFromConstMem(
-                buf.as_ptr() as *const c_void,
-                (buf.len() as c_int).try_into().unwrap(),
-            )
-        };
-
-        if rw.is_null() {
-            return Err(get_error());
-        }
-
-        let raw = unsafe { mixer::Mix_LoadMUS_RW(rw, 0) };
-        if raw.is_null() {
-            Err(get_error())
-        } else {
-            Ok(Music {
-                raw: raw,
-                owned: true,
-                _marker: PhantomData,
-            })
-        }
-    }
-
-    /// The file format encoding of the music.
-    pub fn get_type(&self) -> MusicType {
-        let ret = unsafe { mixer::Mix_GetMusicType(self.raw) as i32 } as c_uint;
-        match ret {
-            mixer::Mix_MusicType_MUS_CMD => MusicType::MusicCmd,
-            mixer::Mix_MusicType_MUS_WAV => MusicType::MusicWav,
-            mixer::Mix_MusicType_MUS_MOD => MusicType::MusicMod,
-            mixer::Mix_MusicType_MUS_MID => MusicType::MusicMid,
-            mixer::Mix_MusicType_MUS_OGG => MusicType::MusicOgg,
-            mixer::Mix_MusicType_MUS_MP3 => MusicType::MusicMp3,
-            mixer::Mix_MusicType_MUS_MP3_MAD_UNUSED => MusicType::MusicMp3Mad,
-            mixer::Mix_MusicType_MUS_FLAC => MusicType::MusicFlac,
-            mixer::Mix_MusicType_MUS_MODPLUG_UNUSED => MusicType::MusicModPlug,
-            mixer::Mix_MusicType_MUS_NONE | _ => MusicType::MusicNone,
-        }
-    }
-
-    /// Play the loaded music loop times through from start to finish. Pass -1 to loop forever.
-    pub fn play(&self, loops: i32) -> Result<(), String> {
-        let ret = unsafe { mixer::Mix_PlayMusic(self.raw, loops as c_int) };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Fade in over ms milliseconds of time, the loaded music,
-    /// playing it loop times through from start to finish.
-    pub fn fade_in(&self, loops: i32, ms: i32) -> Result<(), String> {
-        let ret = unsafe { mixer::Mix_FadeInMusic(self.raw, loops as c_int, ms as c_int) };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Fade in over ms milliseconds of time, from position.
-    pub fn fade_in_from_pos(&self, loops: i32, ms: i32, position: f64) -> Result<(), String> {
-        let ret = unsafe {
-            mixer::Mix_FadeInMusicPos(self.raw, loops as c_int, ms as c_int, position as c_double)
-        };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    // FIXME: make these class method?
-    /// Returns current volume
-    pub fn get_volume() -> i32 {
-        unsafe { mixer::Mix_VolumeMusic(-1) as i32 }
-    }
-
-    /// Set the volume on a scale of 0 to 128.
-    /// Values greater than 128 will use 128.
-    pub fn set_volume(volume: i32) {
-        // This shouldn't return anything. Use get_volume instead
-        let _ = unsafe { mixer::Mix_VolumeMusic(volume as c_int) as i32 };
-    }
-
-    /// Pause the music playback.
-    pub fn pause() {
-        unsafe {
-            mixer::Mix_PauseMusic();
-        }
-    }
-
-    /// Unpause the music.
-    pub fn resume() {
-        unsafe {
-            mixer::Mix_ResumeMusic();
-        }
-    }
-
-    /// Rewind the music to the start.
-    pub fn rewind() {
-        unsafe {
-            mixer::Mix_RewindMusic();
-        }
-    }
-
-    /// Set the position of the currently playing music.
-    pub fn set_pos(position: f64) -> Result<(), String> {
-        let ret = unsafe { mixer::Mix_SetMusicPosition(position as c_double) };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Setup a command line music player to use to play music.
-    pub fn set_command(command: &str) -> Result<(), String> {
-        let ret = unsafe {
-            let c_command = CString::new(command).unwrap();
-            mixer::Mix_SetMusicCMD(c_command.as_ptr())
-        };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Halt playback of music.
-    pub fn halt() {
-        unsafe {
-            mixer::Mix_HaltMusic();
-        }
-    }
-
-    /// Gradually fade out the music over ms milliseconds starting from now.
-    pub fn fade_out(ms: i32) -> Result<(), String> {
-        let ret = unsafe { mixer::Mix_FadeOutMusic(ms as c_int) };
-        if ret == -1 {
-            Err(get_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    // TODO: Mix_HookMusic
-    // TODO: Mix_GetMusicHookData
-
-    /// Sets up a function to be called when music playback is halted.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// fn after_music() {
-    ///     println!("Music has ended");
-    /// }
-    ///
-    /// sdl3::mixer::Music::hook_finished(after_music);
-    /// ```
-    pub fn hook_finished(f: fn()) {
-        unsafe {
-            MUSIC_FINISHED_HOOK = Some(f);
-            mixer::Mix_HookMusicFinished(Some(c_music_finished_hook as extern "C" fn()));
-        }
-    }
-
-    /// A previously set up function would no longer be called when music playback is halted.
-    pub fn unhook_finished() {
-        unsafe {
-            mixer::Mix_HookMusicFinished(None);
-            // unset from c, then rust, to avoid race condition
-            MUSIC_FINISHED_HOOK = None;
-        }
-    }
-
-    /// If music is actively playing, or not.
-    pub fn is_playing() -> bool {
-        unsafe { mixer::Mix_PlayingMusic() == 1 }
-    }
-
-    /// If music is paused, or not.
-    pub fn is_paused() -> bool {
-        unsafe { mixer::Mix_PausedMusic() == 1 }
-    }
-
-    /// If music is fading, or not.
-    pub fn get_fading() -> Fading {
-        let ret = unsafe { mixer::Mix_FadingMusic() as i32 } as c_uint;
-        match ret {
-            mixer::Mix_Fading_MIX_FADING_OUT => Fading::FadingOut,
-            mixer::Mix_Fading_MIX_FADING_IN => Fading::FadingIn,
-            mixer::Mix_Fading_MIX_NO_FADING | _ => Fading::NoFading,
-        }
-    }
-}
-
-// 4.6 Effects
-
-// TODO: Mix_RegisterEffect
-// TODO: Mix_UnregisterEffect
-// TODO: Mix_SetPostMix

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -44,10 +44,16 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// SDL3_mixer is reference-counted internally, so multiple contexts can exist.
 /// The library is only deinitialized when the last context is dropped.
 #[must_use]
-#[derive(Clone)]
 pub struct MixerContext;
 
 static MIXER_COUNT: AtomicU32 = AtomicU32::new(0);
+
+impl Clone for MixerContext {
+    fn clone(&self) -> Self {
+        MIXER_COUNT.fetch_add(1, Ordering::Relaxed);
+        MixerContext
+    }
+}
 
 impl MixerContext {
     fn new() -> Result<Self, Error> {
@@ -59,6 +65,15 @@ impl MixerContext {
             }
         }
         Ok(Self)
+    }
+}
+
+/// Convert an SDL bool return to a Rust Result.
+fn bool_result(ok: bool) -> Result<(), Error> {
+    if ok {
+        Ok(())
+    } else {
+        Err(get_error())
     }
 }
 

--- a/src/sdl3/mixer/track.rs
+++ b/src/sdl3/mixer/track.rs
@@ -290,7 +290,11 @@ impl<'mixer> Track<'mixer> {
     pub fn tags(&self) -> Vec<String> {
         let mut count: std::ffi::c_int = 0;
         let tags_ptr = unsafe { sys::MIX_GetTrackTags(self.raw, &mut count) };
-        if tags_ptr.is_null() || count <= 0 {
+        if tags_ptr.is_null() {
+            return Vec::new();
+        }
+        if count <= 0 {
+            unsafe { sdl3_sys::stdinc::SDL_free(tags_ptr as *mut _) };
             return Vec::new();
         }
         let mut result = Vec::with_capacity(count as usize);

--- a/src/sdl3/mixer/track.rs
+++ b/src/sdl3/mixer/track.rs
@@ -1,0 +1,363 @@
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::ptr;
+
+use crate::{get_error, Error};
+use sdl3_sys::properties::SDL_PropertiesID;
+use sdl3_sys::stdinc::Sint64;
+
+use super::audio::Audio;
+use super::device::Mixer;
+use super::sys;
+
+/// 3D coordinates for positional audio.
+///
+/// Uses a right-handed coordinate system (like OpenGL/OpenAL):
+/// - X: negative left, positive right
+/// - Y: negative down, positive up
+/// - Z: negative forward, positive back
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Point3D {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+/// Per-channel gain for stereo panning.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct StereoGains {
+    pub left: f32,
+    pub right: f32,
+}
+
+/// A track on a mixer that plays audio.
+///
+/// Tracks are the primary way to play sounds. Each track manages its own audio
+/// source, gain, loops, position, and effects. Multiple tracks can play
+/// simultaneously on the same mixer.
+///
+/// A track must not outlive its parent mixer (enforced by the lifetime
+/// parameter).
+pub struct Track<'mixer> {
+    raw: *mut sys::MIX_Track,
+    _marker: PhantomData<&'mixer Mixer>,
+}
+
+impl<'mixer> Track<'mixer> {
+    pub(crate) fn from_raw(raw: *mut sys::MIX_Track) -> Self {
+        Track {
+            raw,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get a pointer to the underlying `MIX_Track`.
+    #[inline]
+    pub fn raw(&self) -> *mut sys::MIX_Track {
+        self.raw
+    }
+
+    // -- Input assignment --
+
+    /// Set the audio data for this track.
+    ///
+    /// The track holds an internal reference to the audio, so it's safe to drop
+    /// the `Audio` object after this call — the track will keep it alive.
+    #[doc(alias = "MIX_SetTrackAudio")]
+    pub fn set_audio(&self, audio: &Audio) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackAudio(self.raw, audio.raw()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Remove the audio input from this track.
+    #[doc(alias = "MIX_SetTrackAudio")]
+    pub fn clear_audio(&self) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackAudio(self.raw, ptr::null_mut()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    // -- Playback control --
+
+    /// Start (or restart) playing this track.
+    ///
+    /// For advanced options (fade-in, start position, loops, etc.), use
+    /// `play_with_options`.
+    #[doc(alias = "MIX_PlayTrack")]
+    pub fn play(&self) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_PlayTrack(self.raw, SDL_PropertiesID(0)) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Stop this track, with optional fade-out in sample frames.
+    ///
+    /// Use `ms_to_frames` to convert milliseconds to frames.
+    /// Pass 0 for immediate stop.
+    #[doc(alias = "MIX_StopTrack")]
+    pub fn stop(&self, fade_out_frames: i64) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_StopTrack(self.raw, fade_out_frames as Sint64) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Pause this track.
+    #[doc(alias = "MIX_PauseTrack")]
+    pub fn pause(&self) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_PauseTrack(self.raw) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Resume this track if paused.
+    #[doc(alias = "MIX_ResumeTrack")]
+    pub fn resume(&self) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_ResumeTrack(self.raw) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Check if this track is currently playing.
+    #[doc(alias = "MIX_TrackPlaying")]
+    pub fn is_playing(&self) -> bool {
+        unsafe { sys::MIX_TrackPlaying(self.raw) }
+    }
+
+    /// Check if this track is currently paused.
+    #[doc(alias = "MIX_TrackPaused")]
+    pub fn is_paused(&self) -> bool {
+        unsafe { sys::MIX_TrackPaused(self.raw) }
+    }
+
+    // -- Gain --
+
+    /// Set the gain (volume) for this track.
+    ///
+    /// A gain of 0.0 is silence, 1.0 is unchanged, >1.0 amplifies.
+    #[doc(alias = "MIX_SetTrackGain")]
+    pub fn set_gain(&self, gain: f32) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackGain(self.raw, gain) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Get the current gain (volume) for this track.
+    #[doc(alias = "MIX_GetTrackGain")]
+    pub fn gain(&self) -> f32 {
+        unsafe { sys::MIX_GetTrackGain(self.raw) }
+    }
+
+    // -- Looping --
+
+    /// Set the number of additional loops for this track.
+    ///
+    /// - 0: play once (no loops)
+    /// - 1: play twice (one loop)
+    /// - -1: loop forever
+    #[doc(alias = "MIX_SetTrackLoops")]
+    pub fn set_loops(&self, loops: i32) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackLoops(self.raw, loops) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Get the current loop count for this track.
+    #[doc(alias = "MIX_GetTrackLoops")]
+    pub fn loops(&self) -> i32 {
+        unsafe { sys::MIX_GetTrackLoops(self.raw) }
+    }
+
+    // -- Position --
+
+    /// Set the playback position in sample frames.
+    #[doc(alias = "MIX_SetTrackPlaybackPosition")]
+    pub fn set_playback_position(&self, frames: i64) -> Result<(), Error> {
+        let ok = unsafe { sys::MIX_SetTrackPlaybackPosition(self.raw, frames as Sint64) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Get the current playback position in sample frames.
+    #[doc(alias = "MIX_GetTrackPlaybackPosition")]
+    pub fn playback_position(&self) -> i64 {
+        unsafe { sys::MIX_GetTrackPlaybackPosition(self.raw) as i64 }
+    }
+
+    /// Get the number of sample frames remaining for this track.
+    #[doc(alias = "MIX_GetTrackRemaining")]
+    pub fn remaining(&self) -> i64 {
+        unsafe { sys::MIX_GetTrackRemaining(self.raw) as i64 }
+    }
+
+    /// Get the number of sample frames in the current fade effect.
+    #[doc(alias = "MIX_GetTrackFadeFrames")]
+    pub fn fade_frames(&self) -> i64 {
+        unsafe { sys::MIX_GetTrackFadeFrames(self.raw) as i64 }
+    }
+
+    // -- Time conversion --
+
+    /// Convert milliseconds to sample frames for this track.
+    #[doc(alias = "MIX_TrackMSToFrames")]
+    pub fn ms_to_frames(&self, ms: i64) -> i64 {
+        unsafe { sys::MIX_TrackMSToFrames(self.raw, ms as Sint64) as i64 }
+    }
+
+    /// Convert sample frames to milliseconds for this track.
+    #[doc(alias = "MIX_TrackFramesToMS")]
+    pub fn frames_to_ms(&self, frames: i64) -> i64 {
+        unsafe { sys::MIX_TrackFramesToMS(self.raw, frames as Sint64) as i64 }
+    }
+
+    // -- Spatial audio --
+
+    /// Set this track's position in 3D space.
+    ///
+    /// This enables distance attenuation and spatialization. On stereo setups,
+    /// sounds will appear to move left/right. On surround-sound setups, sounds
+    /// can move around the listener.
+    #[doc(alias = "MIX_SetTrack3DPosition")]
+    pub fn set_3d_position(&self, pos: Point3D) -> Result<(), Error> {
+        let c_pos = sys::MIX_Point3D {
+            x: pos.x,
+            y: pos.y,
+            z: pos.z,
+        };
+        let ok = unsafe { sys::MIX_SetTrack3DPosition(self.raw, &c_pos) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Get this track's current 3D position.
+    #[doc(alias = "MIX_GetTrack3DPosition")]
+    pub fn get_3d_position(&self) -> Result<Point3D, Error> {
+        let mut c_pos = sys::MIX_Point3D {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let ok = unsafe { sys::MIX_GetTrack3DPosition(self.raw, &mut c_pos) };
+        if ok {
+            Ok(Point3D {
+                x: c_pos.x,
+                y: c_pos.y,
+                z: c_pos.z,
+            })
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Force stereo output with left/right panning.
+    ///
+    /// Pass `None` to disable spatialization entirely (both forced-stereo
+    /// and 3D positioning).
+    #[doc(alias = "MIX_SetTrackStereo")]
+    pub fn set_stereo(&self, gains: Option<StereoGains>) -> Result<(), Error> {
+        let ok = match gains {
+            Some(g) => {
+                let c_gains = sys::MIX_StereoGains {
+                    left: g.left,
+                    right: g.right,
+                };
+                unsafe { sys::MIX_SetTrackStereo(self.raw, &c_gains) }
+            }
+            None => unsafe { sys::MIX_SetTrackStereo(self.raw, ptr::null()) },
+        };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    // -- Tagging --
+
+    /// Add a tag to this track for batch operations.
+    #[doc(alias = "MIX_TagTrack")]
+    pub fn tag(&self, tag: &str) -> Result<(), Error> {
+        let c_tag = CString::new(tag).unwrap();
+        let ok = unsafe { sys::MIX_TagTrack(self.raw, c_tag.as_ptr()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(get_error())
+        }
+    }
+
+    /// Remove a tag from this track.
+    ///
+    /// Pass `None` to remove all tags.
+    #[doc(alias = "MIX_UntagTrack")]
+    pub fn untag(&self, tag: Option<&str>) {
+        match tag {
+            Some(t) => {
+                let c_tag = CString::new(t).unwrap();
+                unsafe { sys::MIX_UntagTrack(self.raw, c_tag.as_ptr()) };
+            }
+            None => {
+                unsafe { sys::MIX_UntagTrack(self.raw, ptr::null()) };
+            }
+        }
+    }
+
+    /// Get all tags currently associated with this track.
+    #[doc(alias = "MIX_GetTrackTags")]
+    pub fn tags(&self) -> Vec<String> {
+        let mut count: std::ffi::c_int = 0;
+        let tags_ptr = unsafe { sys::MIX_GetTrackTags(self.raw, &mut count) };
+        if tags_ptr.is_null() || count <= 0 {
+            return Vec::new();
+        }
+        let mut result = Vec::with_capacity(count as usize);
+        for i in 0..count as isize {
+            unsafe {
+                let tag = *tags_ptr.offset(i);
+                if !tag.is_null() {
+                    if let Ok(s) = CStr::from_ptr(tag).to_str() {
+                        result.push(s.to_owned());
+                    }
+                }
+            }
+        }
+        unsafe { sdl3_sys::stdinc::SDL_free(tags_ptr as *mut _) };
+        result
+    }
+}
+
+impl Drop for Track<'_> {
+    fn drop(&mut self) {
+        unsafe { sys::MIX_DestroyTrack(self.raw) };
+    }
+}

--- a/src/sdl3/mixer/track.rs
+++ b/src/sdl3/mixer/track.rs
@@ -8,7 +8,7 @@ use sdl3_sys::stdinc::Sint64;
 
 use super::audio::Audio;
 use super::device::Mixer;
-use super::sys;
+use super::{bool_result, sys};
 
 /// 3D coordinates for positional audio.
 ///
@@ -21,6 +21,26 @@ pub struct Point3D {
     pub x: f32,
     pub y: f32,
     pub z: f32,
+}
+
+impl From<sys::MIX_Point3D> for Point3D {
+    fn from(p: sys::MIX_Point3D) -> Self {
+        Point3D {
+            x: p.x,
+            y: p.y,
+            z: p.z,
+        }
+    }
+}
+
+impl From<Point3D> for sys::MIX_Point3D {
+    fn from(p: Point3D) -> Self {
+        sys::MIX_Point3D {
+            x: p.x,
+            y: p.y,
+            z: p.z,
+        }
+    }
 }
 
 /// Per-channel gain for stereo panning.
@@ -62,26 +82,16 @@ impl<'mixer> Track<'mixer> {
     /// Set the audio data for this track.
     ///
     /// The track holds an internal reference to the audio, so it's safe to drop
-    /// the `Audio` object after this call — the track will keep it alive.
+    /// the `Audio` object after this call -- the track will keep it alive.
     #[doc(alias = "MIX_SetTrackAudio")]
     pub fn set_audio(&self, audio: &Audio) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackAudio(self.raw, audio.raw()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackAudio(self.raw, audio.raw()) })
     }
 
     /// Remove the audio input from this track.
     #[doc(alias = "MIX_SetTrackAudio")]
     pub fn clear_audio(&self) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackAudio(self.raw, ptr::null_mut()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackAudio(self.raw, ptr::null_mut()) })
     }
 
     // -- Playback control --
@@ -92,12 +102,7 @@ impl<'mixer> Track<'mixer> {
     /// `play_with_options`.
     #[doc(alias = "MIX_PlayTrack")]
     pub fn play(&self) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_PlayTrack(self.raw, SDL_PropertiesID(0)) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_PlayTrack(self.raw, SDL_PropertiesID(0)) })
     }
 
     /// Stop this track, with optional fade-out in sample frames.
@@ -106,34 +111,19 @@ impl<'mixer> Track<'mixer> {
     /// Pass 0 for immediate stop.
     #[doc(alias = "MIX_StopTrack")]
     pub fn stop(&self, fade_out_frames: i64) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_StopTrack(self.raw, fade_out_frames as Sint64) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_StopTrack(self.raw, fade_out_frames as Sint64) })
     }
 
     /// Pause this track.
     #[doc(alias = "MIX_PauseTrack")]
     pub fn pause(&self) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_PauseTrack(self.raw) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_PauseTrack(self.raw) })
     }
 
     /// Resume this track if paused.
     #[doc(alias = "MIX_ResumeTrack")]
     pub fn resume(&self) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_ResumeTrack(self.raw) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_ResumeTrack(self.raw) })
     }
 
     /// Check if this track is currently playing.
@@ -155,12 +145,7 @@ impl<'mixer> Track<'mixer> {
     /// A gain of 0.0 is silence, 1.0 is unchanged, >1.0 amplifies.
     #[doc(alias = "MIX_SetTrackGain")]
     pub fn set_gain(&self, gain: f32) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackGain(self.raw, gain) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackGain(self.raw, gain) })
     }
 
     /// Get the current gain (volume) for this track.
@@ -178,12 +163,7 @@ impl<'mixer> Track<'mixer> {
     /// - -1: loop forever
     #[doc(alias = "MIX_SetTrackLoops")]
     pub fn set_loops(&self, loops: i32) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackLoops(self.raw, loops) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackLoops(self.raw, loops) })
     }
 
     /// Get the current loop count for this track.
@@ -197,12 +177,7 @@ impl<'mixer> Track<'mixer> {
     /// Set the playback position in sample frames.
     #[doc(alias = "MIX_SetTrackPlaybackPosition")]
     pub fn set_playback_position(&self, frames: i64) -> Result<(), Error> {
-        let ok = unsafe { sys::MIX_SetTrackPlaybackPosition(self.raw, frames as Sint64) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_SetTrackPlaybackPosition(self.raw, frames as Sint64) })
     }
 
     /// Get the current playback position in sample frames.
@@ -246,17 +221,8 @@ impl<'mixer> Track<'mixer> {
     /// can move around the listener.
     #[doc(alias = "MIX_SetTrack3DPosition")]
     pub fn set_3d_position(&self, pos: Point3D) -> Result<(), Error> {
-        let c_pos = sys::MIX_Point3D {
-            x: pos.x,
-            y: pos.y,
-            z: pos.z,
-        };
-        let ok = unsafe { sys::MIX_SetTrack3DPosition(self.raw, &c_pos) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        let c_pos: sys::MIX_Point3D = pos.into();
+        bool_result(unsafe { sys::MIX_SetTrack3DPosition(self.raw, &c_pos) })
     }
 
     /// Get this track's current 3D position.
@@ -269,11 +235,7 @@ impl<'mixer> Track<'mixer> {
         };
         let ok = unsafe { sys::MIX_GetTrack3DPosition(self.raw, &mut c_pos) };
         if ok {
-            Ok(Point3D {
-                x: c_pos.x,
-                y: c_pos.y,
-                z: c_pos.z,
-            })
+            Ok(c_pos.into())
         } else {
             Err(get_error())
         }
@@ -295,11 +257,7 @@ impl<'mixer> Track<'mixer> {
             }
             None => unsafe { sys::MIX_SetTrackStereo(self.raw, ptr::null()) },
         };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(ok)
     }
 
     // -- Tagging --
@@ -308,12 +266,7 @@ impl<'mixer> Track<'mixer> {
     #[doc(alias = "MIX_TagTrack")]
     pub fn tag(&self, tag: &str) -> Result<(), Error> {
         let c_tag = CString::new(tag).unwrap();
-        let ok = unsafe { sys::MIX_TagTrack(self.raw, c_tag.as_ptr()) };
-        if ok {
-            Ok(())
-        } else {
-            Err(get_error())
-        }
+        bool_result(unsafe { sys::MIX_TagTrack(self.raw, c_tag.as_ptr()) })
     }
 
     /// Remove a tag from this track.

--- a/src/sdl3/mixer/track.rs
+++ b/src/sdl3/mixer/track.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::ptr;
 
@@ -8,7 +8,7 @@ use sdl3_sys::stdinc::Sint64;
 
 use super::audio::Audio;
 use super::device::Mixer;
-use super::{bool_result, sys};
+use super::{bool_result, sys, to_cstring};
 
 /// 3D coordinates for positional audio.
 ///
@@ -98,8 +98,7 @@ impl<'mixer> Track<'mixer> {
 
     /// Start (or restart) playing this track.
     ///
-    /// For advanced options (fade-in, start position, loops, etc.), use
-    /// `play_with_options`.
+    /// This uses the default playback properties.
     #[doc(alias = "MIX_PlayTrack")]
     pub fn play(&self) -> Result<(), Error> {
         bool_result(unsafe { sys::MIX_PlayTrack(self.raw, SDL_PropertiesID(0)) })
@@ -265,7 +264,7 @@ impl<'mixer> Track<'mixer> {
     /// Add a tag to this track for batch operations.
     #[doc(alias = "MIX_TagTrack")]
     pub fn tag(&self, tag: &str) -> Result<(), Error> {
-        let c_tag = CString::new(tag).unwrap();
+        let c_tag = to_cstring(tag)?;
         bool_result(unsafe { sys::MIX_TagTrack(self.raw, c_tag.as_ptr()) })
     }
 
@@ -273,16 +272,17 @@ impl<'mixer> Track<'mixer> {
     ///
     /// Pass `None` to remove all tags.
     #[doc(alias = "MIX_UntagTrack")]
-    pub fn untag(&self, tag: Option<&str>) {
+    pub fn untag(&self, tag: Option<&str>) -> Result<(), Error> {
         match tag {
             Some(t) => {
-                let c_tag = CString::new(t).unwrap();
+                let c_tag = to_cstring(t)?;
                 unsafe { sys::MIX_UntagTrack(self.raw, c_tag.as_ptr()) };
             }
             None => {
                 unsafe { sys::MIX_UntagTrack(self.raw, ptr::null()) };
             }
         }
+        Ok(())
     }
 
     /// Get all tags currently associated with this track.


### PR DESCRIPTION
Rewrites the mixer module to target the new SDL3_mixer API via sdl3-mixer-sys 0.6.1 (SDL_mixer 3.2.0). The old module was a rust-sdl2 port that targeted the incompatible SDL2_mixer API and was marked as blocked.

SDL3_mixer is a complete API redesign: channels become opaque tracks, Chunk/Music merge into unified Audio, volume switches to float gain, etc. This is a full rewrite rather than an incremental update.

New safe wrapper types:

- `Mixer` - device lifecycle, master gain, lock guard, factory methods for tracks/audio
- `Audio` - loaded audio data, duration/format queries, independent of mixer lifetime
- `Track<'mixer>` - playback control, gain, loops, seeking, 3D positioning, stereo panning, tagging
- `Group<'mixer>` - track grouping (minimal for now, expandable later)

The example (mixer-demo.rs) is rewritten to use the new API. CI now tests the mixer feature across all platforms and build modes.

Not included yet (follow-up PRs):
- Callback support (stopped, raw, cooked, post-mix)
- Memory-only mixer + MIX_Generate
- AudioDecoder streaming API
- Channel mapping, frequency ratio controls
- Play options via SDL_Properties (fade-in, start position, etc.)