### PR TITLE
feat: mixer advanced API surface

### DIFF
--- a/src/sdl3/mixer/audio.rs
+++ b/src/sdl3/mixer/audio.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::properties::Properties;
 use crate::{get_error, Error};
 use sdl3_sys::audio::SDL_AudioSpec;
 use sdl3_sys::stdinc::Sint64;
@@ -65,6 +66,16 @@ impl Audio {
     #[doc(alias = "MIX_AudioFramesToMS")]
     pub fn frames_to_ms(&self, frames: i64) -> i64 {
         unsafe { sys::MIX_AudioFramesToMS(self.raw, frames as Sint64) as i64 }
+    }
+
+    /// Get the properties associated with this audio.
+    ///
+    /// Properties include metadata (title, artist, album, etc.) if the
+    /// audio format supports it. Use `MIX_PROP_METADATA_*` constants as keys.
+    #[doc(alias = "MIX_GetAudioProperties")]
+    pub fn properties(&self) -> Properties {
+        let id = unsafe { sys::MIX_GetAudioProperties(self.raw) };
+        Properties::const_from_ll(id)
     }
 }
 

--- a/src/sdl3/mixer/device.rs
+++ b/src/sdl3/mixer/device.rs
@@ -250,12 +250,16 @@ impl Mixer {
     /// specific tracks. The returned pointers are borrowed from the mixer and
     /// must not be destroyed.
     #[doc(alias = "MIX_GetTaggedTracks")]
-    pub fn tagged_tracks(&self, tag: &str) -> Vec<*mut sys::MIX_Track> {
-        let c_tag = to_cstring(tag).unwrap_or_default();
+    pub fn tagged_tracks(&self, tag: &str) -> Result<Vec<*mut sys::MIX_Track>, Error> {
+        let c_tag = to_cstring(tag)?;
         let mut count: std::ffi::c_int = 0;
         let ptr = unsafe { sys::MIX_GetTaggedTracks(self.raw, c_tag.as_ptr(), &mut count) };
-        if ptr.is_null() || count <= 0 {
-            return Vec::new();
+        if ptr.is_null() {
+            return Ok(Vec::new());
+        }
+        if count <= 0 {
+            unsafe { sdl3_sys::stdinc::SDL_free(ptr as *mut _) };
+            return Ok(Vec::new());
         }
         let mut result = Vec::with_capacity(count as usize);
         for i in 0..count as isize {
@@ -267,14 +271,12 @@ impl Mixer {
             }
         }
         unsafe { sdl3_sys::stdinc::SDL_free(ptr as *mut _) };
-        result
+        Ok(result)
     }
 
     // -- Properties --
 
     /// Get the properties associated with this mixer.
-    ///
-    /// The returned properties object is read-only.
     #[doc(alias = "MIX_GetMixerProperties")]
     pub fn properties(&self) -> Properties {
         let id = unsafe { sys::MIX_GetMixerProperties(self.raw) };
@@ -353,7 +355,8 @@ impl Mixer {
     /// Returns the number of bytes written, or a negative value on error.
     #[doc(alias = "MIX_Generate")]
     pub fn generate(&self, buffer: &mut [u8]) -> i32 {
-        unsafe { sys::MIX_Generate(self.raw, buffer.as_mut_ptr() as *mut _, buffer.len() as i32) }
+        let len = buffer.len().min(i32::MAX as usize) as i32;
+        unsafe { sys::MIX_Generate(self.raw, buffer.as_mut_ptr() as *mut _, len) }
     }
 }
 

--- a/src/sdl3/mixer/device.rs
+++ b/src/sdl3/mixer/device.rs
@@ -2,8 +2,11 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::ptr;
 
+use crate::iostream::IOStream;
+use crate::properties::Properties;
 use crate::{get_error, Error};
 use sdl3_sys::audio::{SDL_AudioDeviceID, SDL_AudioSpec, SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK};
+use sdl3_sys::properties::SDL_PropertiesID;
 use sdl3_sys::stdinc::Sint64;
 
 use super::audio::Audio;
@@ -199,6 +202,158 @@ impl Mixer {
     pub fn resume_tag(&self, tag: &str) -> Result<(), Error> {
         let c_tag = to_cstring(tag)?;
         bool_result(unsafe { sys::MIX_ResumeTag(self.raw, c_tag.as_ptr()) })
+    }
+
+    // -- Frequency ratio --
+
+    /// Set the master frequency ratio for the entire mix.
+    ///
+    /// 1.0 is normal speed, 2.0 is double speed, 0.5 is half speed.
+    #[doc(alias = "MIX_SetMixerFrequencyRatio")]
+    pub fn set_frequency_ratio(&self, ratio: f32) -> Result<(), Error> {
+        bool_result(unsafe { sys::MIX_SetMixerFrequencyRatio(self.raw, ratio) })
+    }
+
+    /// Get the master frequency ratio for the entire mix.
+    #[doc(alias = "MIX_GetMixerFrequencyRatio")]
+    pub fn frequency_ratio(&self) -> f32 {
+        unsafe { sys::MIX_GetMixerFrequencyRatio(self.raw) }
+    }
+
+    // -- Tag-based gain --
+
+    /// Set the gain for all tracks with a specific tag.
+    #[doc(alias = "MIX_SetTagGain")]
+    pub fn set_tag_gain(&self, tag: &str, gain: f32) -> Result<(), Error> {
+        let c_tag = to_cstring(tag)?;
+        bool_result(unsafe { sys::MIX_SetTagGain(self.raw, c_tag.as_ptr(), gain) })
+    }
+
+    // -- Tag-based playback --
+
+    /// Start playing all tracks with a specific tag.
+    ///
+    /// Pass `None` for options to use default playback properties, or create
+    /// a `Properties` object and set `MIX_PROP_PLAY_*` keys for advanced control.
+    #[doc(alias = "MIX_PlayTag")]
+    pub fn play_tag(&self, tag: &str, options: Option<&Properties>) -> Result<(), Error> {
+        let c_tag = to_cstring(tag)?;
+        let props = options.map_or(SDL_PropertiesID(0), |p| p.raw());
+        bool_result(unsafe { sys::MIX_PlayTag(self.raw, c_tag.as_ptr(), props) })
+    }
+
+    // -- Tag queries --
+
+    /// Get the raw track pointers for all tracks with a specific tag.
+    ///
+    /// Returns raw pointers that can be compared with `track.raw()` to identify
+    /// specific tracks. The returned pointers are borrowed from the mixer and
+    /// must not be destroyed.
+    #[doc(alias = "MIX_GetTaggedTracks")]
+    pub fn tagged_tracks(&self, tag: &str) -> Vec<*mut sys::MIX_Track> {
+        let c_tag = to_cstring(tag).unwrap_or_default();
+        let mut count: std::ffi::c_int = 0;
+        let ptr = unsafe { sys::MIX_GetTaggedTracks(self.raw, c_tag.as_ptr(), &mut count) };
+        if ptr.is_null() || count <= 0 {
+            return Vec::new();
+        }
+        let mut result = Vec::with_capacity(count as usize);
+        for i in 0..count as isize {
+            unsafe {
+                let track = *ptr.offset(i);
+                if !track.is_null() {
+                    result.push(track);
+                }
+            }
+        }
+        unsafe { sdl3_sys::stdinc::SDL_free(ptr as *mut _) };
+        result
+    }
+
+    // -- Properties --
+
+    /// Get the properties associated with this mixer.
+    ///
+    /// The returned properties object is read-only.
+    #[doc(alias = "MIX_GetMixerProperties")]
+    pub fn properties(&self) -> Properties {
+        let id = unsafe { sys::MIX_GetMixerProperties(self.raw) };
+        Properties::const_from_ll(id)
+    }
+
+    // -- IOStream loading --
+
+    /// Load audio from an IOStream.
+    ///
+    /// If `predecode` is true, the audio will be fully decompressed into memory.
+    /// Otherwise it will be decoded on the fly during playback.
+    #[doc(alias = "MIX_LoadAudio_IO")]
+    pub fn load_audio_io(&self, io: &IOStream, predecode: bool) -> Result<Audio, Error> {
+        let raw = unsafe { sys::MIX_LoadAudio_IO(self.raw, io.raw(), predecode, false) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Audio::from_raw(raw))
+        }
+    }
+
+    /// Load raw PCM audio data from a byte slice.
+    ///
+    /// The data is copied internally, so the slice does not need to outlive
+    /// the returned `Audio`.
+    #[doc(alias = "MIX_LoadRawAudio")]
+    pub fn load_raw_audio(&self, data: &[u8], spec: &SDL_AudioSpec) -> Result<Audio, Error> {
+        let raw =
+            unsafe { sys::MIX_LoadRawAudio(self.raw, data.as_ptr() as *const _, data.len(), spec) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Audio::from_raw(raw))
+        }
+    }
+
+    /// Load raw PCM audio from an IOStream.
+    #[doc(alias = "MIX_LoadRawAudio_IO")]
+    pub fn load_raw_audio_io(&self, io: &IOStream, spec: &SDL_AudioSpec) -> Result<Audio, Error> {
+        let raw = unsafe { sys::MIX_LoadRawAudio_IO(self.raw, io.raw(), spec, false) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Audio::from_raw(raw))
+        }
+    }
+
+    // -- Memory-only mixer --
+
+    /// Create a mixer that renders to memory instead of an audio device.
+    ///
+    /// Use `generate` to pull mixed audio into a buffer. Pass `None` for `spec`
+    /// to let SDL choose the best format.
+    #[doc(alias = "MIX_CreateMixer")]
+    pub fn create_memory(spec: Option<&SDL_AudioSpec>) -> Result<Mixer, Error> {
+        let context = MixerContext::new()?;
+        let spec_ptr = spec
+            .map(|s| s as *const SDL_AudioSpec)
+            .unwrap_or(ptr::null());
+        let raw = unsafe { sys::MIX_CreateMixer(spec_ptr) };
+        if raw.is_null() {
+            Err(get_error())
+        } else {
+            Ok(Mixer {
+                raw,
+                _context: context,
+                _marker: PhantomData,
+            })
+        }
+    }
+
+    /// Generate mixed audio into a buffer.
+    ///
+    /// Only valid for memory-only mixers created with `create_memory`.
+    /// Returns the number of bytes written, or a negative value on error.
+    #[doc(alias = "MIX_Generate")]
+    pub fn generate(&self, buffer: &mut [u8]) -> i32 {
+        unsafe { sys::MIX_Generate(self.raw, buffer.as_mut_ptr() as *mut _, buffer.len() as i32) }
     }
 }
 

--- a/src/sdl3/mixer/group.rs
+++ b/src/sdl3/mixer/group.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::properties::Properties;
 use crate::Error;
 
 use super::device::Mixer;
@@ -46,6 +47,15 @@ impl<'mixer> Group<'mixer> {
     #[doc(alias = "MIX_SetTrackGroup")]
     pub fn remove_track(&self, track: &Track) -> Result<(), Error> {
         bool_result(unsafe { sys::MIX_SetTrackGroup(track.raw(), std::ptr::null_mut()) })
+    }
+
+    /// Get the properties associated with this group.
+    ///
+    /// The returned properties object is read-only.
+    #[doc(alias = "MIX_GetGroupProperties")]
+    pub fn properties(&self) -> Properties {
+        let id = unsafe { sys::MIX_GetGroupProperties(self.raw) };
+        Properties::const_from_ll(id)
     }
 }
 

--- a/src/sdl3/mixer/group.rs
+++ b/src/sdl3/mixer/group.rs
@@ -51,7 +51,8 @@ impl<'mixer> Group<'mixer> {
 
     /// Get the properties associated with this group.
     ///
-    /// The returned properties object is read-only.
+    /// The returned `Properties` is borrowed from SDL and will not be
+    /// destroyed when dropped.
     #[doc(alias = "MIX_GetGroupProperties")]
     pub fn properties(&self) -> Properties {
         let id = unsafe { sys::MIX_GetGroupProperties(self.raw) };

--- a/src/sdl3/mixer/mod.rs
+++ b/src/sdl3/mixer/mod.rs
@@ -35,7 +35,27 @@ pub use self::device::{Mixer, MixerLock};
 pub use self::group::Group;
 pub use self::track::{Point3D, StereoGains, Track};
 
+// Re-export property key constants for play options, audio loading, and metadata.
+pub use sys::{
+    MIX_DURATION_INFINITE, MIX_DURATION_UNKNOWN, MIX_PROP_AUDIO_DECODER_STRING,
+    MIX_PROP_AUDIO_LOAD_CLOSEIO_BOOLEAN, MIX_PROP_AUDIO_LOAD_IOSTREAM_POINTER,
+    MIX_PROP_AUDIO_LOAD_PREDECODE_BOOLEAN, MIX_PROP_AUDIO_LOAD_PREFERRED_MIXER_POINTER,
+    MIX_PROP_AUDIO_LOAD_SKIP_METADATA_TAGS_BOOLEAN, MIX_PROP_METADATA_ALBUM_STRING,
+    MIX_PROP_METADATA_ARTIST_STRING, MIX_PROP_METADATA_COPYRIGHT_STRING,
+    MIX_PROP_METADATA_DURATION_FRAMES_NUMBER, MIX_PROP_METADATA_DURATION_INFINITE_BOOLEAN,
+    MIX_PROP_METADATA_TITLE_STRING, MIX_PROP_METADATA_TOTAL_TRACKS_NUMBER,
+    MIX_PROP_METADATA_TRACK_NUMBER, MIX_PROP_METADATA_YEAR_NUMBER, MIX_PROP_MIXER_DEVICE_NUMBER,
+    MIX_PROP_PLAY_APPEND_SILENCE_FRAMES_NUMBER, MIX_PROP_PLAY_APPEND_SILENCE_MILLISECONDS_NUMBER,
+    MIX_PROP_PLAY_FADE_IN_FRAMES_NUMBER, MIX_PROP_PLAY_FADE_IN_MILLISECONDS_NUMBER,
+    MIX_PROP_PLAY_FADE_IN_START_GAIN_FLOAT, MIX_PROP_PLAY_HALT_WHEN_EXHAUSTED_BOOLEAN,
+    MIX_PROP_PLAY_LOOPS_NUMBER, MIX_PROP_PLAY_LOOP_START_FRAME_NUMBER,
+    MIX_PROP_PLAY_LOOP_START_MILLISECOND_NUMBER, MIX_PROP_PLAY_MAX_FRAME_NUMBER,
+    MIX_PROP_PLAY_MAX_MILLISECONDS_NUMBER, MIX_PROP_PLAY_START_FRAME_NUMBER,
+    MIX_PROP_PLAY_START_MILLISECOND_NUMBER,
+};
+
 use crate::{get_error, Error};
+use sdl3_sys::stdinc::Sint64;
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 
@@ -138,4 +158,20 @@ pub fn get_audio_decoder(index: i32) -> Option<String> {
             )
         }
     }
+}
+
+/// Convert milliseconds to sample frames at a given sample rate.
+///
+/// This is a standalone helper that doesn't require a track or audio object.
+#[doc(alias = "MIX_MSToFrames")]
+pub fn ms_to_frames(sample_rate: i32, ms: i64) -> i64 {
+    unsafe { sys::MIX_MSToFrames(sample_rate, ms as Sint64) as i64 }
+}
+
+/// Convert sample frames to milliseconds at a given sample rate.
+///
+/// This is a standalone helper that doesn't require a track or audio object.
+#[doc(alias = "MIX_FramesToMS")]
+pub fn frames_to_ms(sample_rate: i32, frames: i64) -> i64 {
+    unsafe { sys::MIX_FramesToMS(sample_rate, frames as Sint64) as i64 }
 }

--- a/src/sdl3/mixer/track.rs
+++ b/src/sdl3/mixer/track.rs
@@ -2,6 +2,7 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::ptr;
 
+use crate::properties::Properties;
 use crate::{get_error, Error};
 use sdl3_sys::properties::SDL_PropertiesID;
 use sdl3_sys::stdinc::Sint64;
@@ -102,6 +103,15 @@ impl<'mixer> Track<'mixer> {
     #[doc(alias = "MIX_PlayTrack")]
     pub fn play(&self) -> Result<(), Error> {
         bool_result(unsafe { sys::MIX_PlayTrack(self.raw, SDL_PropertiesID(0)) })
+    }
+
+    /// Start (or restart) playing this track with advanced options.
+    ///
+    /// Create a `Properties` object and set `MIX_PROP_PLAY_*` keys for
+    /// fade-in, start position, max duration, loop points, etc.
+    #[doc(alias = "MIX_PlayTrack")]
+    pub fn play_with_options(&self, options: &Properties) -> Result<(), Error> {
+        bool_result(unsafe { sys::MIX_PlayTrack(self.raw, options.raw()) })
     }
 
     /// Stop this track, with optional fade-out in sample frames.
@@ -257,6 +267,111 @@ impl<'mixer> Track<'mixer> {
             None => unsafe { sys::MIX_SetTrackStereo(self.raw, ptr::null()) },
         };
         bool_result(ok)
+    }
+
+    // -- Frequency ratio --
+
+    /// Set the frequency ratio (playback speed) for this track.
+    ///
+    /// 1.0 is normal speed, 2.0 is double speed, 0.5 is half speed.
+    #[doc(alias = "MIX_SetTrackFrequencyRatio")]
+    pub fn set_frequency_ratio(&self, ratio: f32) -> Result<(), Error> {
+        bool_result(unsafe { sys::MIX_SetTrackFrequencyRatio(self.raw, ratio) })
+    }
+
+    /// Get the frequency ratio (playback speed) for this track.
+    #[doc(alias = "MIX_GetTrackFrequencyRatio")]
+    pub fn frequency_ratio(&self) -> f32 {
+        unsafe { sys::MIX_GetTrackFrequencyRatio(self.raw) }
+    }
+
+    // -- Channel mapping --
+
+    /// Set the output channel map for this track.
+    ///
+    /// Each element maps an output channel index to an input channel index.
+    /// Pass an empty slice to reset to the default mapping.
+    #[doc(alias = "MIX_SetTrackOutputChannelMap")]
+    pub fn set_output_channel_map(&self, map: &[i32]) -> Result<(), Error> {
+        if map.is_empty() {
+            bool_result(unsafe { sys::MIX_SetTrackOutputChannelMap(self.raw, ptr::null(), 0) })
+        } else {
+            bool_result(unsafe {
+                sys::MIX_SetTrackOutputChannelMap(self.raw, map.as_ptr(), map.len() as i32)
+            })
+        }
+    }
+
+    // -- Properties --
+
+    /// Get the properties associated with this track.
+    ///
+    /// The returned properties object is read-only.
+    #[doc(alias = "MIX_GetTrackProperties")]
+    pub fn properties(&self) -> Properties {
+        let id = unsafe { sys::MIX_GetTrackProperties(self.raw) };
+        Properties::const_from_ll(id)
+    }
+
+    // -- Track queries --
+
+    /// Get the raw pointer to the audio currently assigned to this track.
+    ///
+    /// Returns null if no audio is assigned. The pointer is borrowed from
+    /// the track and must not be destroyed.
+    #[doc(alias = "MIX_GetTrackAudio")]
+    pub fn audio_raw(&self) -> *mut sys::MIX_Audio {
+        unsafe { sys::MIX_GetTrackAudio(self.raw) }
+    }
+
+    /// Get the raw pointer to this track's audio stream.
+    ///
+    /// Returns null if there is no active audio stream.
+    #[doc(alias = "MIX_GetTrackAudioStream")]
+    pub fn audio_stream_raw(&self) -> *mut sdl3_sys::audio::SDL_AudioStream {
+        unsafe { sys::MIX_GetTrackAudioStream(self.raw) }
+    }
+
+    /// Get the raw pointer to this track's parent mixer.
+    #[doc(alias = "MIX_GetTrackMixer")]
+    pub fn mixer_raw(&self) -> *mut sys::MIX_Mixer {
+        unsafe { sys::MIX_GetTrackMixer(self.raw) }
+    }
+
+    // -- Streaming input --
+
+    /// Set an SDL audio stream as input for this track.
+    ///
+    /// The track will pull audio from the stream during mixing.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `stream` is a valid, non-null `SDL_AudioStream`
+    /// pointer that remains valid for the lifetime of the track.
+    #[doc(alias = "MIX_SetTrackAudioStream")]
+    pub unsafe fn set_audio_stream(
+        &self,
+        stream: *mut sdl3_sys::audio::SDL_AudioStream,
+    ) -> Result<(), Error> {
+        bool_result(unsafe { sys::MIX_SetTrackAudioStream(self.raw, stream) })
+    }
+
+    /// Set an IOStream as input for this track (encoded audio).
+    ///
+    /// The mixer will decode the stream on the fly during playback.
+    #[doc(alias = "MIX_SetTrackIOStream")]
+    pub fn set_iostream(&self, io: &crate::iostream::IOStream) -> Result<(), Error> {
+        bool_result(unsafe { sys::MIX_SetTrackIOStream(self.raw, io.raw(), false) })
+    }
+
+    /// Set an IOStream as input for this track (raw PCM audio).
+    #[doc(alias = "MIX_SetTrackRawIOStream")]
+    pub fn set_raw_iostream(
+        &self,
+        io: &crate::iostream::IOStream,
+        spec: &sdl3_sys::audio::SDL_AudioSpec,
+    ) -> Result<(), Error> {
+        bool_result(unsafe { sys::MIX_SetTrackRawIOStream(self.raw, io.raw(), spec, false) })
     }
 
     // -- Tagging --

--- a/src/sdl3/mixer/track.rs
+++ b/src/sdl3/mixer/track.rs
@@ -296,17 +296,15 @@ impl<'mixer> Track<'mixer> {
         if map.is_empty() {
             bool_result(unsafe { sys::MIX_SetTrackOutputChannelMap(self.raw, ptr::null(), 0) })
         } else {
-            bool_result(unsafe {
-                sys::MIX_SetTrackOutputChannelMap(self.raw, map.as_ptr(), map.len() as i32)
-            })
+            let count =
+                i32::try_from(map.len()).map_err(|_| Error("channel map too large".into()))?;
+            bool_result(unsafe { sys::MIX_SetTrackOutputChannelMap(self.raw, map.as_ptr(), count) })
         }
     }
 
     // -- Properties --
 
     /// Get the properties associated with this track.
-    ///
-    /// The returned properties object is read-only.
     #[doc(alias = "MIX_GetTrackProperties")]
     pub fn properties(&self) -> Properties {
         let id = unsafe { sys::MIX_GetTrackProperties(self.raw) };


### PR DESCRIPTION
Builds on #356 to cover the remaining non-callback SDL3_mixer API.

Adds frequency ratio, play options via SDL Properties, IOStream-based audio loading, raw PCM loading, properties access on Mixer/Track/Audio/Group, tag-based gain and playback, tagged track queries, channel mapping, streaming track input (AudioStream and IOStream), memory-only mixer with generate, and standalone time conversion helpers.

Also re-exports all MIX_PROP_PLAY_*, MIX_PROP_METADATA_*, and MIX_DURATION_* constants so users can work with the property-based APIs without reaching into the sys crate.

Still deferred to a separate PR: callbacks (stopped, raw, cooked, post-mix, group post-mix) and the standalone AudioDecoder type. These need careful unsafe closure design that warrants its own review.