### PR TITLE
chore: Release sdl3 version 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdl3"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bitflags 2.10.0",
  "c_vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "sdl3"
 description = "Bindings to SDL3, a cross-platform library to abstract the platform-specific details for building applications."
 repository = "https://github.com/vhspace/sdl3-rs"
 documentation = "https://docs.rs/sdl3/latest/sdl3/"
-version = "0.18.0"
+version = "0.18.1"
 license = "MIT"
 authors = [
     "Tony Aldridge <tony@angry-lawyer.com>",


### PR DESCRIPTION
## Summary

Patch release to test the hardened publish workflow.

- Bump version to 0.18.1
- Update Cargo.lock