### PR TITLE
fix: one missing occurence of WindowEvent::Occluded

### DIFF
--- a/src/sdl3/event.rs
+++ b/src/sdl3/event.rs
@@ -418,6 +418,7 @@ impl TryFrom<u32> for EventType {
             SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED => WindowPixelSizeChanged,
             SDL_EVENT_WINDOW_MINIMIZED => WindowMinimized,
             SDL_EVENT_WINDOW_MAXIMIZED => WindowMaximized,
+            SDL_EVENT_WINDOW_OCCLUDED => WindowOccluded,
             SDL_EVENT_WINDOW_RESTORED => WindowRestored,
             SDL_EVENT_WINDOW_MOUSE_ENTER => WindowMouseEnter,
             SDL_EVENT_WINDOW_MOUSE_LEAVE => WindowMouseLeave,


### PR DESCRIPTION
Follow-up of #347

Sorry I missed one occurrence in my previous PR.
I have confirmed this PR works fine locally.