### PR TITLE
feat: Add bindings for Virtual joysticks in sdl3::joysticks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,7 +293,7 @@ required-features = ["raw-window-handle"]
 name = "raw-window-handle-with-wgpu"
 
 [[example]]
-name = "virt-joysticks"
+name = "virtual-joysticks"
 
 [package.metadata.vcpkg]
 dependencies = ["sdl3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,9 @@ name = "window-properties"
 required-features = ["raw-window-handle"]
 name = "raw-window-handle-with-wgpu"
 
+[[example]]
+name = "virt-joysticks"
+
 [package.metadata.vcpkg]
 dependencies = ["sdl3"]
 

--- a/examples/virt-joysticks.rs
+++ b/examples/virt-joysticks.rs
@@ -1,0 +1,120 @@
+use sdl3::{
+    gamepad::{Axis, Button},
+    joystick::{HatState, VirtualJoystickDescription},
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n<===> VIRTUAL JOYSTICKS <===>\n");
+    let sdl_context = sdl3::init()?;
+    let joystick_subsystem = sdl_context.joystick()?;
+
+    let axes: Vec<Axis> = vec![Axis::LeftX, Axis::LeftY];
+    let buttons: Vec<Button> = vec![Button::North, Button::South, Button::East, Button::West];
+
+    {
+        let desc = VirtualJoystickDescription::new()
+            .num_hats(1)
+            .with_axes(axes.clone())
+            .with_buttons(buttons.clone())
+            .name("My Virtual Joystick");
+
+        println!(
+            "Current number of joysticks: {}\n",
+            joystick_subsystem.joysticks().unwrap().len()
+        );
+
+        // `connection` is of type VirtualJoystickConnection, which behaves like a physical connection
+        // between a physical device and your PC. If it leaves scope and is dropped, it is analogous to
+        // you unplugging your mouse from your PC while a program is currently using it.
+        let connection = joystick_subsystem.attach_virt_joystick(desc)?;
+        println!("Successfully built a new virtual joystick.");
+
+        println!(
+            "New number of joysticks: {}\n",
+            joystick_subsystem.joysticks().unwrap().len()
+        );
+
+        let id = connection.id();
+        let joystick = joystick_subsystem.open(id)?;
+
+        println!(
+            "Joystick:\n   Name: {}\n   Number of Axes: {}\n   Number of Buttons: {}\n   Number of Hats: {}\n",
+            joystick.name(),
+            joystick.num_axes(),
+            joystick.num_buttons(),
+            joystick.num_hats()
+        );
+
+        let axes_iter = axes.iter();
+        let buttons_iter = buttons.iter();
+
+        let axis_codes: Vec<u32> = axes_iter.map(|axis| axis.to_ll().0 as u32).collect();
+        let button_codes: Vec<u32> = buttons_iter.map(|button| button.to_ll().0 as u32).collect();
+
+        println!("Values before write:");
+        println!(
+            "{:<3}Axes (LX/LY):      {}/{}",
+            "",
+            joystick.axis(axis_codes[0]).unwrap(), // Axis::LeftX
+            joystick.axis(axis_codes[1]).unwrap()  // Axis::LeftY
+        );
+
+        println!(
+            "{:<3}Buttons (N/S/E/W): {}/{}/{}/{}",
+            "",
+            joystick.button(button_codes[0]).unwrap(), // Button::North
+            joystick.button(button_codes[1]).unwrap(), // Button::South
+            joystick.button(button_codes[2]).unwrap(), // Button::East
+            joystick.button(button_codes[3]).unwrap()  // Button::West
+        );
+        println!(
+            "{:<3}Hat 0:             {:?}\n",
+            "",
+            joystick.hat(0).unwrap()
+        );
+
+        println!("Writing new states to the virtual joystick...\n");
+        joystick.set_virtual_axis(axis_codes[0], 100)?; // Axis::LeftX
+        joystick.set_virtual_axis(axis_codes[1], 200)?; // Axis::LeftY
+        joystick.set_virtual_button(button_codes[0], true)?; // Button::North
+        joystick.set_virtual_button(button_codes[1], true)?; // Button::South
+        joystick.set_virtual_button(button_codes[2], true)?; // Button::East
+        joystick.set_virtual_button(button_codes[3], true)?; // Button::West
+        joystick.set_virtual_hat(0, HatState::Up)?;
+
+        // update() must be called for the new states to be flushed
+        joystick_subsystem.update();
+
+        println!("Values after write:");
+        println!(
+            "{:<3}Axes (LX/LY):      {}/{}",
+            "",
+            joystick.axis(axis_codes[0]).unwrap(), // Axis::LeftX
+            joystick.axis(axis_codes[1]).unwrap()  // Axis::LeftY
+        );
+
+        println!(
+            "{:<3}Buttons (N/S/E/W): {}/{}/{}/{}",
+            "",
+            joystick.button(button_codes[0]).unwrap(), // Button::North
+            joystick.button(button_codes[1]).unwrap(), // Button::South
+            joystick.button(button_codes[2]).unwrap(), // Button::East
+            joystick.button(button_codes[3]).unwrap()  // Button::West
+        );
+        println!(
+            "{:<3}Hat 0:             {:?}\n",
+            "",
+            joystick.hat(0).unwrap()
+        );
+
+        println!("Lifetime of Virtual Joystick Connection ends here.")
+    }
+
+    // By this point, the the Virtual Joystick Connection has been dropped, so it should no longer
+    // be counted in joystick_subsystem().joysticks()
+    println!(
+        "Final number of joysticks: {}",
+        joystick_subsystem.joysticks().unwrap().len()
+    );
+    Ok(())
+}

--- a/examples/virtual-joysticks.rs
+++ b/examples/virtual-joysticks.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // `connection` is of type VirtualJoystickConnection, which behaves like a physical connection
         // between a physical device and your PC. If it leaves scope and is dropped, it is analogous to
         // you unplugging your mouse from your PC while a program is currently using it.
-        let connection = joystick_subsystem.attach_virt_joystick(desc)?;
+        let connection = joystick_subsystem.attach_virtual_joystick(desc)?;
         println!("Successfully built a new virtual joystick.");
 
         println!(

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -94,9 +94,14 @@ impl JoystickSubsystem {
         raw_desc.button_mask = desc.button_mask;
 
         let joystick_id = unsafe { sys::joystick::SDL_AttachVirtualJoystick(&raw_desc) };
-        let joystick = self.open(joystick_id)?;
 
-        Ok(VirtualJoystickConnection { inner: joystick })
+        if joystick_id.0 == 0 {
+            Err(IntegerOrSdlError::SdlError(get_error()))
+        } else {
+            let joystick = self.open(joystick_id)?;
+
+            Ok(VirtualJoystickConnection { inner: joystick })
+        }
     }
 }
 

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -740,7 +740,8 @@ impl VirtualJoystickDescription {
         }
     }
 
-    /// Set the joystick name
+    /// Set the joystick name. The name is truncated at the first interior NUL
+    /// byte, since C strings cannot contain NUL.
     pub fn name(self, name: &str) -> Self {
         let mut desc = self;
         desc.name = string_to_c_str(name);

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -555,6 +555,56 @@ impl ConnectionState {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(i32)]
+pub enum JoystickType {
+    Unknown = sys::joystick::SDL_JoystickType::UNKNOWN.0,
+    Gamepad = sys::joystick::SDL_JoystickType::GAMEPAD.0,
+    Wheel = sys::joystick::SDL_JoystickType::WHEEL.0,
+    ArcadeStick = sys::joystick::SDL_JoystickType::ARCADE_STICK.0,
+    FlightStick = sys::joystick::SDL_JoystickType::FLIGHT_STICK.0,
+    DancePad = sys::joystick::SDL_JoystickType::DANCE_PAD.0,
+    Guitar = sys::joystick::SDL_JoystickType::GUITAR.0,
+    DrumKit = sys::joystick::SDL_JoystickType::DRUM_KIT.0,
+    ArcadePad = sys::joystick::SDL_JoystickType::ARCADE_PAD.0,
+    Throttle = sys::joystick::SDL_JoystickType::THROTTLE.0,
+    Count = sys::joystick::SDL_JoystickType::COUNT.0,
+}
+
+impl JoystickType {
+    pub fn from_ll(kind: sys::joystick::SDL_JoystickType) -> JoystickType {
+        match kind {
+            sys::joystick::SDL_JoystickType::GAMEPAD => JoystickType::Gamepad,
+            sys::joystick::SDL_JoystickType::WHEEL => JoystickType::Wheel,
+            sys::joystick::SDL_JoystickType::ARCADE_STICK => JoystickType::ArcadeStick,
+            sys::joystick::SDL_JoystickType::FLIGHT_STICK => JoystickType::FlightStick,
+            sys::joystick::SDL_JoystickType::DANCE_PAD => JoystickType::DancePad,
+            sys::joystick::SDL_JoystickType::GUITAR => JoystickType::Guitar,
+            sys::joystick::SDL_JoystickType::DRUM_KIT => JoystickType::DrumKit,
+            sys::joystick::SDL_JoystickType::ARCADE_PAD => JoystickType::ArcadePad,
+            sys::joystick::SDL_JoystickType::THROTTLE => JoystickType::Throttle,
+            sys::joystick::SDL_JoystickType::COUNT => JoystickType::Count,
+            sys::joystick::SDL_JoystickType::UNKNOWN | _ => JoystickType::Unknown,
+        }
+    }
+
+    pub fn to_ll(self) -> sys::joystick::SDL_JoystickType {
+        match self {
+            JoystickType::Unknown => sys::joystick::SDL_JoystickType::UNKNOWN,
+            JoystickType::Gamepad => sys::joystick::SDL_JoystickType::GAMEPAD,
+            JoystickType::Wheel => sys::joystick::SDL_JoystickType::WHEEL,
+            JoystickType::ArcadeStick => sys::joystick::SDL_JoystickType::ARCADE_STICK,
+            JoystickType::FlightStick => sys::joystick::SDL_JoystickType::FLIGHT_STICK,
+            JoystickType::DancePad => sys::joystick::SDL_JoystickType::DANCE_PAD,
+            JoystickType::Guitar => sys::joystick::SDL_JoystickType::GUITAR,
+            JoystickType::DrumKit => sys::joystick::SDL_JoystickType::DRUM_KIT,
+            JoystickType::ArcadePad => sys::joystick::SDL_JoystickType::ARCADE_PAD,
+            JoystickType::Throttle => sys::joystick::SDL_JoystickType::THROTTLE,
+            JoystickType::Count => sys::joystick::SDL_JoystickType::COUNT,
+        }
+    }
+}
+
 /// Convert C string `c_str` to a String. Return an empty string if
 /// `c_str` is NULL.
 fn c_str_to_string(c_str: *const c_char) -> String {

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -639,3 +639,17 @@ impl Drop for VirtualJoystickConnection {
         unsafe { sys::joystick::SDL_DetachVirtualJoystick(id) };
     }
 }
+
+/// As of SDL3, Virtual Devices must be initialized using a description.
+pub struct VirtualJoystickDescription {
+    name: *const c_char,
+    joystick_type: JoystickType,
+    num_axes: u16,
+    num_buttons: u16,
+    num_hats: u16,
+
+    // Virtual Joysticks require specification as to what each of its buttons and axes are actually
+    // mapped to.
+    axis_mask: u32,
+    button_mask: u32,
+}

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -74,12 +74,12 @@ impl JoystickSubsystem {
 
     /// Check if a joystick is virtual
     #[doc(alias = "SDL_IsJoystickVirtual")]
-    pub fn virt(&self, joystick_id: JoystickId) -> bool {
+    pub fn is_virtual(&self, joystick_id: JoystickId) -> bool {
         unsafe { sys::joystick::SDL_IsJoystickVirtual(joystick_id) }
     }
 
     /// Attach a virtual joystick
-    pub fn attach_virt_joystick(
+    pub fn attach_virtual_joystick(
         &self,
         desc: VirtualJoystickDescription,
     ) -> Result<VirtualJoystickConnection, IntegerOrSdlError> {
@@ -485,7 +485,7 @@ impl Joystick {
 
     /// Check if a joystick is virtual
     #[doc(alias = "SDL_IsJoystickVirtual")]
-    pub fn virt(&self) -> bool {
+    pub fn is_virtual(&self) -> bool {
         let id = sys::joystick::SDL_JoystickID(self.id());
         unsafe { sys::joystick::SDL_IsJoystickVirtual(id) }
     }

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -617,7 +617,7 @@ impl ConnectionState {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[repr(i32)]
 pub enum JoystickType {
     Unknown = sys::joystick::SDL_JoystickType::UNKNOWN.0,

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -83,8 +83,17 @@ impl JoystickSubsystem {
         &self,
         desc: VirtualJoystickDescription,
     ) -> Result<VirtualJoystickConnection, IntegerOrSdlError> {
-        let desc = desc.to_ll();
-        let joystick_id = unsafe { sys::joystick::SDL_AttachVirtualJoystick(&desc) };
+        let mut raw_desc = sys::joystick::SDL_VirtualJoystickDesc::new();
+
+        raw_desc.name = desc.name.as_ptr();
+        raw_desc.r#type = desc.joystick_type.to_ll().0 as u16;
+        raw_desc.naxes = desc.num_axes;
+        raw_desc.nbuttons = desc.num_buttons;
+        raw_desc.nhats = desc.num_hats;
+        raw_desc.axis_mask = desc.axis_mask;
+        raw_desc.button_mask = desc.button_mask;
+
+        let joystick_id = unsafe { sys::joystick::SDL_AttachVirtualJoystick(&raw_desc) };
         let joystick = self.open(joystick_id)?;
 
         Ok(VirtualJoystickConnection { inner: joystick })
@@ -666,9 +675,8 @@ fn c_str_to_string(c_str: *const c_char) -> String {
 }
 
 /// Conversely, this converts a string slice `string` into a C string.
-fn string_to_c_str(string: &str) -> *const c_char {
-    let cstr = CString::new(string).unwrap();
-    cstr.as_ptr() as *const c_char
+fn string_to_c_str(string: &str) -> CString {
+    CString::new(string).unwrap()
 }
 
 /// Represents the lifetime of a virtual joystick connection
@@ -696,7 +704,7 @@ impl Drop for VirtualJoystickConnection {
 
 /// As of SDL3, Virtual Devices must be initialized using a description.
 pub struct VirtualJoystickDescription {
-    name: *const c_char,
+    name: CString,
     joystick_type: JoystickType,
     num_axes: u16,
     num_buttons: u16,
@@ -787,19 +795,6 @@ impl VirtualJoystickDescription {
         for button in buttons {
             desc = desc.with_button(button);
         }
-        desc
-    }
-
-    /// Convert the VirtualJoystickDescription into a form usable by SDL's underlying code
-    pub fn to_ll(self) -> sys::joystick::SDL_VirtualJoystickDesc {
-        let mut desc = sys::joystick::SDL_VirtualJoystickDesc::new();
-        desc.name = self.name;
-        desc.r#type = self.joystick_type.to_ll().0 as u16;
-        desc.naxes = self.num_axes;
-        desc.nbuttons = self.num_buttons;
-        desc.nhats = self.num_hats;
-        desc.axis_mask = self.axis_mask;
-        desc.button_mask = self.button_mask;
         desc
     }
 }

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -8,7 +8,7 @@ use crate::guid::Guid;
 use crate::Error;
 use crate::JoystickSubsystem;
 use libc::{c_char, c_void};
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::fmt;
 use sys::power::{SDL_PowerState, SDL_POWERSTATE_UNKNOWN};
 use sys::stdinc::SDL_free;
@@ -617,6 +617,12 @@ fn c_str_to_string(c_str: *const c_char) -> String {
     }
 }
 
+/// Conversely, this converts a string slice `string` into a C string.
+fn string_to_c_str(string: &str) -> *const c_char {
+    let cstr = CString::new(string).unwrap();
+    cstr.as_ptr() as *const c_char
+}
+
 /// Represents the lifetime of a virtual joystick connection
 pub struct VirtualJoystickConnection {
     inner: Joystick,
@@ -652,4 +658,99 @@ pub struct VirtualJoystickDescription {
     // mapped to.
     axis_mask: u32,
     button_mask: u32,
+}
+
+impl VirtualJoystickDescription {
+    pub fn new() -> Self {
+        Self {
+            name: string_to_c_str("Unnamed Virtual Joystick"),
+            joystick_type: JoystickType::Unknown,
+            num_axes: 0,
+            num_buttons: 0,
+            num_hats: 0,
+            axis_mask: 0,
+            button_mask: 0,
+        }
+    }
+
+    /// Set the joystick name
+    pub fn name(self, name: &str) -> Self {
+        let mut desc = self;
+        desc.name = string_to_c_str(name);
+        desc
+    }
+
+    /// Set the joystick type
+    pub fn joystick_type(self, joystick_type: JoystickType) -> Self {
+        let mut desc = self;
+        desc.joystick_type = joystick_type;
+        desc
+    }
+
+    /// Set the number of hats
+    pub fn num_hats(self, num_hats: u16) -> Self {
+        let mut desc = self;
+        desc.num_hats = num_hats;
+        desc
+    }
+
+    /// Specifies that a given axis can be controlled by the virtual joystick
+    pub fn with_axis(self, axis: crate::gamepad::Axis) -> Self {
+        let mut desc = self;
+        let axis_code = axis.to_ll().0 as u16;
+
+        // num_axes must be equal to at least 1 + the highest enum value of axes added to the
+        // joystick
+        if axis_code >= desc.num_axes {
+            desc.num_axes = axis_code + 1;
+        }
+
+        desc.axis_mask |= 1 << axis_code;
+        desc
+    }
+
+    /// Specifies that a given button can be controlled by the virtual joystick
+    pub fn with_button(self, button: crate::gamepad::Button) -> Self {
+        let mut desc = self;
+        let button_code = button.to_ll().0 as u16;
+
+        // num_buttons must be equal to at least 1 + the highest enum value of buttons added to the
+        // joystick
+        if button_code >= desc.num_buttons {
+            desc.num_buttons = button_code + 1;
+        }
+
+        desc.button_mask |= 1 << button_code;
+        desc
+    }
+
+    /// Specifies that a given list of axes can be controlled by the virtual joystick
+    pub fn with_axes(self, axes: Vec<crate::gamepad::Axis>) -> Self {
+        let mut desc = self;
+        for axis in axes {
+            desc = desc.with_axis(axis);
+        }
+        desc
+    }
+
+    /// Specifies that a given list of buttons can be controlled by the virtual joystick
+    pub fn with_buttons(self, buttons: Vec<crate::gamepad::Button>) -> Self {
+        let mut desc = self;
+        for button in buttons {
+            desc = desc.with_button(button);
+        }
+        desc
+    }
+
+    /// Convert the VirtualJoystickDescription into a form usable by SDL's underlying code
+    pub fn to_ll(self) -> sys::joystick::SDL_VirtualJoystickDesc {
+        let mut desc = sys::joystick::SDL_VirtualJoystickDesc::new();
+        desc.r#type = self.joystick_type.to_ll().0 as u16;
+        desc.naxes = self.num_axes;
+        desc.nbuttons = self.num_buttons;
+        desc.nhats = self.num_hats;
+        desc.axis_mask = self.axis_mask;
+        desc.button_mask = self.button_mask;
+        desc
+    }
 }

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -71,6 +71,12 @@ impl JoystickSubsystem {
     pub fn update(&self) {
         unsafe { sys::joystick::SDL_UpdateJoysticks() };
     }
+
+    /// Check if a joystick is virtual
+    #[doc(alias = "SDL_IsJoystickVirtual")]
+    pub fn virt(&self, joystick_id: JoystickId) -> bool {
+        unsafe { sys::joystick::SDL_IsJoystickVirtual(joystick_id) }
+    }
 }
 
 // power level and percentage together
@@ -449,6 +455,13 @@ impl Joystick {
         } else {
             Ok(())
         }
+    }
+
+    /// Check if a joystick is virtual
+    #[doc(alias = "SDL_IsJoystickVirtual")]
+    pub fn virt(&self) -> bool {
+        let id = sys::joystick::SDL_JoystickID(self.id());
+        unsafe { sys::joystick::SDL_IsJoystickVirtual(id) }
     }
 }
 

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -616,3 +616,26 @@ fn c_str_to_string(c_str: *const c_char) -> String {
         String::from_utf8_lossy(bytes).to_string()
     }
 }
+
+/// Represents the lifetime of a virtual joystick connection
+pub struct VirtualJoystickConnection {
+    inner: Joystick,
+}
+
+impl VirtualJoystickConnection {
+    /// Exposes the instance ID of the attached virtual joystick so that it can be opened
+    pub fn id(&self) -> JoystickId {
+        sys::joystick::SDL_JoystickID(self.inner.id())
+    }
+}
+
+/// When a VirtualJoystickConnection is dropped, the underlying virtual device will be disconnected.
+/// For any existing virtual joysticks relying on that connection, it will be analogous to a physical
+/// piece of hardware being unplugged while being used by a non-virtual joystick.
+impl Drop for VirtualJoystickConnection {
+    #[doc(alias = "SDL_DetachVirtualJoystick")]
+    fn drop(&mut self) {
+        let id = sys::joystick::SDL_JoystickID(self.inner.id());
+        unsafe { sys::joystick::SDL_DetachVirtualJoystick(id) };
+    }
+}

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -793,7 +793,10 @@ impl VirtualJoystickDescription {
     }
 
     /// Specifies that a given list of axes can be controlled by the virtual joystick
-    pub fn with_axes(self, axes: Vec<crate::gamepad::Axis>) -> Self {
+    pub fn with_axes<T>(self, axes: T) -> Self
+    where
+        T: IntoIterator<Item = crate::gamepad::Axis>,
+    {
         let mut desc = self;
         for axis in axes {
             desc = desc.with_axis(axis);
@@ -802,7 +805,10 @@ impl VirtualJoystickDescription {
     }
 
     /// Specifies that a given list of buttons can be controlled by the virtual joystick
-    pub fn with_buttons(self, buttons: Vec<crate::gamepad::Button>) -> Self {
+    pub fn with_buttons<T>(self, buttons: T) -> Self
+    where
+        T: IntoIterator<Item = crate::gamepad::Button>,
+    {
         let mut desc = self;
         for button in buttons {
             desc = desc.with_button(button);

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -630,7 +630,6 @@ pub enum JoystickType {
     DrumKit = sys::joystick::SDL_JoystickType::DRUM_KIT.0,
     ArcadePad = sys::joystick::SDL_JoystickType::ARCADE_PAD.0,
     Throttle = sys::joystick::SDL_JoystickType::THROTTLE.0,
-    Count = sys::joystick::SDL_JoystickType::COUNT.0,
 }
 
 impl JoystickType {
@@ -645,8 +644,7 @@ impl JoystickType {
             sys::joystick::SDL_JoystickType::DRUM_KIT => JoystickType::DrumKit,
             sys::joystick::SDL_JoystickType::ARCADE_PAD => JoystickType::ArcadePad,
             sys::joystick::SDL_JoystickType::THROTTLE => JoystickType::Throttle,
-            sys::joystick::SDL_JoystickType::COUNT => JoystickType::Count,
-            sys::joystick::SDL_JoystickType::UNKNOWN | _ => JoystickType::Unknown,
+            _ => JoystickType::Unknown,
         }
     }
 
@@ -662,7 +660,6 @@ impl JoystickType {
             JoystickType::DrumKit => sys::joystick::SDL_JoystickType::DRUM_KIT,
             JoystickType::ArcadePad => sys::joystick::SDL_JoystickType::ARCADE_PAD,
             JoystickType::Throttle => sys::joystick::SDL_JoystickType::THROTTLE,
-            JoystickType::Count => sys::joystick::SDL_JoystickType::COUNT,
         }
     }
 }
@@ -679,9 +676,12 @@ fn c_str_to_string(c_str: *const c_char) -> String {
     }
 }
 
-/// Conversely, this converts a string slice `string` into a C string.
+/// Convert a string slice into a `CString`, truncating at the first interior
+/// NUL byte. Joystick names cannot contain NUL, so silently dropping the tail
+/// is preferable to panicking on user-supplied input.
 fn string_to_c_str(string: &str) -> CString {
-    CString::new(string).unwrap()
+    let end = string.bytes().position(|b| b == 0).unwrap_or(string.len());
+    CString::new(&string.as_bytes()[..end]).expect("interior NULs stripped above")
 }
 
 /// Represents the lifetime of a virtual joystick connection
@@ -719,6 +719,12 @@ pub struct VirtualJoystickDescription {
     // mapped to.
     axis_mask: u32,
     button_mask: u32,
+}
+
+impl Default for VirtualJoystickDescription {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl VirtualJoystickDescription {

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -793,6 +793,7 @@ impl VirtualJoystickDescription {
     /// Convert the VirtualJoystickDescription into a form usable by SDL's underlying code
     pub fn to_ll(self) -> sys::joystick::SDL_VirtualJoystickDesc {
         let mut desc = sys::joystick::SDL_VirtualJoystickDesc::new();
+        desc.name = self.name;
         desc.r#type = self.joystick_type.to_ll().0 as u16;
         desc.naxes = self.num_axes;
         desc.nbuttons = self.num_buttons;

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -475,6 +475,42 @@ impl Joystick {
         let id = sys::joystick::SDL_JoystickID(self.id());
         unsafe { sys::joystick::SDL_IsJoystickVirtual(id) }
     }
+
+    /// Set a virtual axis state
+    #[doc(alias = "SDL_SetJoystickVirtualAxis")]
+    pub fn set_virtual_axis(&self, axis: u32, state: i16) -> Result<(), IntegerOrSdlError> {
+        let axis = validate_int(axis, "axis")?;
+
+        if unsafe { sys::joystick::SDL_SetJoystickVirtualAxis(self.raw, axis, state) } {
+            Ok(())
+        } else {
+            Err(IntegerOrSdlError::SdlError(get_error()))
+        }
+    }
+
+    /// Set a virtual button state
+    #[doc(alias = "SDL_SetJoystickVirtualButton")]
+    pub fn set_virtual_button(&self, button: u32, state: bool) -> Result<(), IntegerOrSdlError> {
+        let button = validate_int(button, "button")?;
+
+        if unsafe { sys::joystick::SDL_SetJoystickVirtualButton(self.raw, button, state) } {
+            Ok(())
+        } else {
+            Err(IntegerOrSdlError::SdlError(get_error()))
+        }
+    }
+
+    /// Set a virtual hat state
+    #[doc(alias = "SDL_SetJoystickVirtualHat")]
+    pub fn set_virtual_hat(&self, hat: u32, state: HatState) -> Result<(), IntegerOrSdlError> {
+        let hat = validate_int(hat, "hat")?;
+
+        if unsafe { sys::joystick::SDL_SetJoystickVirtualHat(self.raw, hat, state.to_raw()) } {
+            Ok(())
+        } else {
+            Err(IntegerOrSdlError::SdlError(get_error()))
+        }
+    }
 }
 
 impl Drop for Joystick {

--- a/src/sdl3/joystick.rs
+++ b/src/sdl3/joystick.rs
@@ -77,6 +77,18 @@ impl JoystickSubsystem {
     pub fn virt(&self, joystick_id: JoystickId) -> bool {
         unsafe { sys::joystick::SDL_IsJoystickVirtual(joystick_id) }
     }
+
+    /// Attach a virtual joystick
+    pub fn attach_virt_joystick(
+        &self,
+        desc: VirtualJoystickDescription,
+    ) -> Result<VirtualJoystickConnection, IntegerOrSdlError> {
+        let desc = desc.to_ll();
+        let joystick_id = unsafe { sys::joystick::SDL_AttachVirtualJoystick(&desc) };
+        let joystick = self.open(joystick_id)?;
+
+        Ok(VirtualJoystickConnection { inner: joystick })
+    }
 }
 
 // power level and percentage together


### PR DESCRIPTION
Hi! I'm working on a project in Rust that depends on SDL3 and specifically Virtual Joysticks, and I realized that neither sdl3-rs nor the older rust-sdl2 currently have support for Virtual Joysticks. I've taken it upon myself to take the initiative to try and add these bindings in myself.

**Summary of Changes:**
- Add struct ```VirtualJoystickConnection``` to represent the lifetime and connection of a Virtual Joystick, analogous to a physical cord connected to a gamepad
- Add struct ```VirtualJoystickDescription``` used to describe the features of a Virtual Joystick before initializing it
- Implement a function ```attach_virtual_joystick``` to ```JoystickSubsystem``` to create a new virtual joystick and return the lifetime of its connection
- Implement functions ```set_virtual_axis```, ```set_virtual_button```, and ```set_virtual_hat``` for ```Joystick``` in order to control a virtual joystick
- Add a simple example ```virt-joysticks.rs```