### PR TITLE
fix: correct the return value of save_bmp_rw in surface.rs

### DIFF
--- a/src/sdl3/surface.rs
+++ b/src/sdl3/surface.rs
@@ -437,8 +437,8 @@ impl SurfaceRef {
 
     #[doc(alias = "SDL_SaveBMP_RW")]
     pub fn save_bmp_rw(&self, iostream: &mut IOStream) -> Result<(), Error> {
-        let ret = unsafe { sys::surface::SDL_SaveBMP_IO(self.raw(), iostream.raw(), false) };
-        if !ret {
+        let ok = unsafe { sys::surface::SDL_SaveBMP_IO(self.raw(), iostream.raw(), false) };
+        if ok {
             Ok(())
         } else {
             Err(get_error())


### PR DESCRIPTION
Per the [SDL3 `SDL_SaveBMP_IO` documentation ](https://wiki.libsdl.org/SDL3/SDL_SaveBMP_IO), the return value is a boolean for which `false` indicates an error state.

Prior to this PR, `save_bmp_rw` was using an inverted condition check and would return `Err` on success and `Ok` on error, which prevented proper use.