### PR TITLE
chore: bump sdl3-sys to 0.6.5 (SDL 3.4.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,15 +1039,15 @@ dependencies = [
 
 [[package]]
 name = "sdl3-src"
-version = "3.4.4"
+version = "3.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f1cdcc5eb877ad663216c3133bfa5af469628c9573b3d2364e584efe19ab0"
+checksum = "997bff4c8d3d9d1e846d7ad8caa33e6fe18a07ec9dc474e1efbbb20923d87bd9"
 
 [[package]]
 name = "sdl3-sys"
-version = "0.6.3+SDL-3.4.4"
+version = "0.6.5+SDL-3.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7adc59563535710602c8e7035297fd73d2506c0c61677f40aeb8917c0e86a01"
+checksum = "51ca7a36c908d1d2b6c259d426a5000fbb70e764dcc430f6a373cc151f614f68"
 dependencies = [
  "ash",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "2.11.1"
 libc = "0.2.185"
 
 [dependencies.sdl3-sys]
-version = "0.6"
+version = "0.6.5"
 features = ["metadata"]
 
 [dependencies.sdl3-image-sys]
@@ -80,7 +80,7 @@ windows-core = { version = "0.62", features = ["std"] }
 windows = "0.62"
 
 [build-dependencies]
-sdl3-sys = { version = "0.6", features = ["only-metadata"] }
+sdl3-sys = { version = "0.6.5", features = ["only-metadata"] }
 
 
 [features]


### PR DESCRIPTION
Bumps sdl3-sys from 0.6 to 0.6.5+SDL-3.4.8. Latest sdl3-sys also adds a `display-impls` feature and `new` constructors on ID newtypes that we'll use in a follow-up to clean up #322.

Build/clippy/tests pass locally across feature combinations.