### PR TITLE
feat: expose the api call: TTF_GetFontSize

### DIFF
--- a/src/sdl3/ttf/font.rs
+++ b/src/sdl3/ttf/font.rs
@@ -552,6 +552,19 @@ impl<'r> Font<'r> {
         }
     }
 
+    #[doc(alias = "TTF_GetFontSize")]
+    pub fn get_size(&self) -> Result<f32, Error> {
+
+        let ret = unsafe {
+            ttf::TTF_GetFontSize(self.raw)
+        };
+        if ret == 0.0f32 {
+            Err(get_error())
+        } else {
+            Ok(ret)
+        }
+    }
+
     #[doc(alias = "TTF_SetFontSize")]
     pub fn set_size(&self, size: f32) -> Result<(), Error> {
         let ret = unsafe { ttf::TTF_SetFontSize(self.raw, size) };

--- a/src/sdl3/ttf/font.rs
+++ b/src/sdl3/ttf/font.rs
@@ -554,10 +554,7 @@ impl<'r> Font<'r> {
 
     #[doc(alias = "TTF_GetFontSize")]
     pub fn get_size(&self) -> Result<f32, Error> {
-
-        let ret = unsafe {
-            ttf::TTF_GetFontSize(self.raw)
-        };
+        let ret = unsafe { ttf::TTF_GetFontSize(self.raw) };
         if ret == 0.0f32 {
             Err(get_error())
         } else {


### PR DESCRIPTION
I would like to add the get font size function for the ttf font.