### PR TITLE
chore: allow 'net' scope in PR title linter

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -29,6 +29,7 @@ jobs:
             keyboard
             mixer
             mouse
+            net
             ttf
             audio
             clipboard


### PR DESCRIPTION
Mirrors the new 'net' optional feature (see #390) so future SDL3_net PRs can use the scoped form like `feat(net): ...`.