### PR TITLE
feat: return error when enabling/disabling screen saver

### DIFF
--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1140,7 +1140,7 @@ impl VideoSubsystem {
     }
 
     #[doc(alias = "SDL_EnableScreenSaver")]
-    pub fn enable_screen_saver(&self) {
+    pub fn enable_screen_saver(&self) -> Result<(), Error> {
         if unsafe { sys::video::SDL_EnableScreenSaver() } {
             Some(())
         } else {

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1141,12 +1141,20 @@ impl VideoSubsystem {
 
     #[doc(alias = "SDL_EnableScreenSaver")]
     pub fn enable_screen_saver(&self) {
-        unsafe { sys::video::SDL_EnableScreenSaver() };
+        if unsafe { sys::video::SDL_EnableScreenSaver() } {
+            Some(())
+        } else {
+            Err(get_error())
+        }
     }
 
     #[doc(alias = "SDL_DisableScreenSaver")]
-    pub fn disable_screen_saver(&self) {
-        unsafe { sys::video::SDL_DisableScreenSaver() };
+    pub fn disable_screen_saver(&self) -> Result<(), Error> {
+        if unsafe { sys::video::SDL_DisableScreenSaver() } {
+            Some(())
+        } else {
+            Err(get_error())
+        }
     }
 
     /// Loads the default OpenGL library.

--- a/src/sdl3/video.rs
+++ b/src/sdl3/video.rs
@@ -1142,7 +1142,7 @@ impl VideoSubsystem {
     #[doc(alias = "SDL_EnableScreenSaver")]
     pub fn enable_screen_saver(&self) -> Result<(), Error> {
         if unsafe { sys::video::SDL_EnableScreenSaver() } {
-            Some(())
+            Ok(())
         } else {
             Err(get_error())
         }
@@ -1151,7 +1151,7 @@ impl VideoSubsystem {
     #[doc(alias = "SDL_DisableScreenSaver")]
     pub fn disable_screen_saver(&self) -> Result<(), Error> {
         if unsafe { sys::video::SDL_DisableScreenSaver() } {
-            Some(())
+            Ok(())
         } else {
             Err(get_error())
         }


### PR DESCRIPTION
Very simple addition that returns the current SDL Error when either screensaver function is called.