### PR TITLE
README: update status of SDL_sound and SDL_net

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Not all [SDL3 extension libraries](https://wiki.libsdl.org/SDL3/Libraries) have 
 | SDL_gfx  | 🟨 Waiting on improvements to the C library  |
 | SDL_image  | ✅ Supported  |
 | SDL_mixer  | ✅ Supported  |
-| SDL_sound  | 🟨 Awaiting a stable C release   |
+| SDL_sound  | ❌ Not currently supported   |
 | SDL_ttf  | ✅ Supported  |
-| SDL_net  | 🟨 Awaiting a stable C release  |
+| SDL_net  | ❌ Not currently supported  |
 | SDL_shadercross  | ❌ Not currently supported  |
 | sdl3-main | ✅ Supported  |
 


### PR DESCRIPTION
Both SDL_sound and SDL_net have stable SDL3 compatible versions now:

* https://github.com/icculus/SDL_sound/releases/tag/v3.2.0
* https://github.com/libsdl-org/SDL_net/releases/tag/release-3.2.0