### PR TITLE
fix(gpu): Handle null texture case in wait_and_acquire_swapchain_texture

### DIFF
--- a/examples/gpu-clear.rs
+++ b/examples/gpu-clear.rs
@@ -39,7 +39,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // This is because a swapchain needs to be "allocated", and it can quickly run out
         // if we don't properly time the rendering process.
         let mut command_buffer = gpu.acquire_command_buffer()?;
-        if let Ok(swapchain) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
+        if let Ok(Some(swapchain)) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
             let color_targets = [
                 sdl3::gpu::ColorTargetInfo::default()
                     .with_texture(&swapchain) // Use swapchain texture

--- a/examples/gpu-cube.rs
+++ b/examples/gpu-cube.rs
@@ -232,7 +232,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // This is because a swapchain needs to be "allocated", and it can quickly run out
         // if we don't properly time the rendering process.
         let mut command_buffer = gpu.acquire_command_buffer()?;
-        if let Ok(swapchain) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
+        if let Ok(Some(swapchain)) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
             // Again, like in gpu-clear.rs, we'd want to define basic operations for our cube
             let color_targets = [ColorTargetInfo::default()
                 .with_texture(&swapchain)

--- a/examples/gpu-particles.rs
+++ b/examples/gpu-particles.rs
@@ -141,7 +141,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // === Draw ===
         let mut draw_cmd = device.acquire_command_buffer()?;
-        if let Ok(swapchain) = draw_cmd.wait_and_acquire_swapchain_texture(&window) {
+        if let Ok(Some(swapchain)) = draw_cmd.wait_and_acquire_swapchain_texture(&window) {
             let color_target = ColorTargetInfo::default()
                 .with_texture(&swapchain)
                 .with_load_op(LoadOp::CLEAR)

--- a/examples/gpu-texture.rs
+++ b/examples/gpu-texture.rs
@@ -359,7 +359,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // This is because a swapchain needs to be "allocated", and it can quickly run out
         // if we don't properly time the rendering process.
         let mut command_buffer = gpu.acquire_command_buffer()?;
-        if let Ok(swapchain) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
+        if let Ok(Some(swapchain)) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
             // Again, like in gpu-clear.rs, we'd want to define basic operations for our cube
             let color_targets = [ColorTargetInfo::default()
                 .with_texture(&swapchain)

--- a/examples/gpu-triangle.rs
+++ b/examples/gpu-triangle.rs
@@ -88,7 +88,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // This is because a swapchain needs to be "allocated", and it can quickly run out
         // if we don't properly time the rendering process.
         let mut command_buffer = gpu.acquire_command_buffer()?;
-        if let Ok(swapchain) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
+        if let Ok(Some(swapchain)) = command_buffer.wait_and_acquire_swapchain_texture(&window) {
             // Again, like in gpu-clear.rs, we'd want to define basic operations for our triangle
             let color_targets = [
                 ColorTargetInfo::default()

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -111,7 +111,7 @@ impl CommandBuffer {
     pub fn wait_and_acquire_swapchain_texture<'a>(
         &'a mut self,
         w: &crate::video::Window,
-    ) -> Result<Texture<'a>, Error> {
+    ) -> Result<Option<Texture<'a>>, Error> {
         let mut swapchain = std::ptr::null_mut();
         let mut width = 0;
         let mut height = 0;
@@ -125,7 +125,11 @@ impl CommandBuffer {
             )
         };
         if success {
-            Ok(Texture::new_sdl_managed(swapchain, width, height))
+            if swapchain.is_null() {
+                Ok(None)
+            } else {
+                Ok(Some(Texture::new_sdl_managed(swapchain, width, height)))
+            }
         } else {
             Err(get_error())
         }


### PR DESCRIPTION
Fixes #352 

Duplicates the fix already done for `acquire_swapchain_texture` in #240 to `wait_and_acquire_swapchain_texture`.