### PR TITLE
ci: skip cargo publish when the version is already on crates.io

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -45,7 +45,13 @@ jobs:
       - name: Publish Crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if curl -sfA "sdl3-rs-ci" "https://crates.io/api/v1/crates/sdl3/$VERSION" >/dev/null; then
+            echo "sdl3 $VERSION is already on crates.io, skipping publish"
+          else
+            cargo publish --locked
+          fi
 
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2


### PR DESCRIPTION
Releases are cut locally with cargo-release, which publishes to crates.io before the tag ever reaches GitHub. The publish workflow then fails on `cargo publish` (version already exists) and never gets to the Create Release step, so no GitHub release has been produced for any tag so far (v0.20.0 was created by hand).

Check crates.io for the version first and only publish if it's missing. The release step then runs either way.