### PR TITLE
chore(deps): update chacha20 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
chacha20 0.10.0 was yanked from crates.io and cargo warns about it on every package/publish. Lockfile-only change, it's a transitive dev-dependency.