### PR TITLE
feat(gpu): add ColorTargetInfo::with_resolve_texture and MultisampleState builder

### DIFF
--- a/src/sdl3/gpu/mod.rs
+++ b/src/sdl3/gpu/mod.rs
@@ -28,8 +28,8 @@ mod pipeline;
 pub use pipeline::{
     ColorTargetBlendState, ColorTargetDescription, ComputePipeline, ComputePipelineBuilder,
     DepthStencilState, GraphicsPipeline, GraphicsPipelineBuilder, GraphicsPipelineTargetInfo,
-    RasterizerState, StencilOpState, StorageBufferReadWriteBinding, StorageTextureReadWriteBinding,
-    VertexAttribute, VertexInputState,
+    MultisampleState, RasterizerState, StencilOpState, StorageBufferReadWriteBinding,
+    StorageTextureReadWriteBinding, VertexAttribute, VertexInputState,
 };
 
 mod texture;

--- a/src/sdl3/gpu/pass.rs
+++ b/src/sdl3/gpu/pass.rs
@@ -286,6 +286,36 @@ impl ColorTargetInfo {
         self.inner.clear_color.a = (value.a as f32) / 255.0;
         self
     }
+
+    /// The texture that a multisampled color target is resolved into when
+    /// the store op is [`StoreOp::RESOLVE`] or [`StoreOp::RESOLVE_AND_STORE`].
+    /// Must have a sample count of 1.
+    #[doc(alias = "SDL_GPUColorTargetInfo::resolve_texture")]
+    pub fn with_resolve_texture(mut self, texture: &Texture) -> Self {
+        self.inner.resolve_texture = texture.raw();
+        self
+    }
+
+    /// The mip level of the resolve texture to write to.
+    #[doc(alias = "SDL_GPUColorTargetInfo::resolve_mip_level")]
+    pub fn with_resolve_mip_level(mut self, mip_level: u32) -> Self {
+        self.inner.resolve_mip_level = mip_level;
+        self
+    }
+
+    /// The layer index of the resolve texture to write to.
+    #[doc(alias = "SDL_GPUColorTargetInfo::resolve_layer")]
+    pub fn with_resolve_layer(mut self, layer: u32) -> Self {
+        self.inner.resolve_layer = layer;
+        self
+    }
+
+    /// True cycles the resolve texture if it is already bound.
+    #[doc(alias = "SDL_GPUColorTargetInfo::cycle_resolve_texture")]
+    pub fn with_cycle_resolve_texture(mut self, cycle: bool) -> Self {
+        self.inner.cycle_resolve_texture = cycle;
+        self
+    }
 }
 
 #[repr(C)]

--- a/src/sdl3/gpu/pipeline.rs
+++ b/src/sdl3/gpu/pipeline.rs
@@ -2,7 +2,7 @@ use crate::{
     get_error,
     gpu::{
         device::WeakDevice, BlendFactor, BlendOp, ColorComponentFlags, CompareOp, CullMode, Device,
-        FillMode, FrontFace, PrimitiveType, Shader, StencilOp, TextureFormat,
+        FillMode, FrontFace, PrimitiveType, SampleCount, Shader, StencilOp, TextureFormat,
         VertexBufferDescription, VertexElementFormat,
     },
     sys, Error,
@@ -13,11 +13,11 @@ use sys::gpu::{
     SDL_GPUColorTargetDescription, SDL_GPUCompareOp, SDL_GPUComputePipeline,
     SDL_GPUComputePipelineCreateInfo, SDL_GPUCullMode, SDL_GPUDepthStencilState, SDL_GPUFillMode,
     SDL_GPUFrontFace, SDL_GPUGraphicsPipeline, SDL_GPUGraphicsPipelineCreateInfo,
-    SDL_GPUGraphicsPipelineTargetInfo, SDL_GPUPrimitiveType, SDL_GPURasterizerState,
-    SDL_GPUStencilOp, SDL_GPUStencilOpState, SDL_GPUStorageBufferReadWriteBinding,
-    SDL_GPUStorageTextureReadWriteBinding, SDL_GPUTextureFormat, SDL_GPUVertexAttribute,
-    SDL_GPUVertexBufferDescription, SDL_GPUVertexInputState, SDL_ReleaseGPUComputePipeline,
-    SDL_ReleaseGPUGraphicsPipeline,
+    SDL_GPUGraphicsPipelineTargetInfo, SDL_GPUMultisampleState, SDL_GPUPrimitiveType,
+    SDL_GPURasterizerState, SDL_GPUSampleCount, SDL_GPUStencilOp, SDL_GPUStencilOpState,
+    SDL_GPUStorageBufferReadWriteBinding, SDL_GPUStorageTextureReadWriteBinding,
+    SDL_GPUTextureFormat, SDL_GPUVertexAttribute, SDL_GPUVertexBufferDescription,
+    SDL_GPUVertexInputState, SDL_ReleaseGPUComputePipeline, SDL_ReleaseGPUGraphicsPipeline,
 };
 
 use super::{Buffer, ShaderFormat, Texture};
@@ -104,6 +104,13 @@ impl<'a> GraphicsPipelineBuilder<'a> {
 
     pub fn with_depth_stencil_state(mut self, value: DepthStencilState) -> Self {
         self.inner.depth_stencil_state = value.inner;
+        self
+    }
+
+    /// Sets the multisample state of the graphics pipeline.
+    #[doc(alias = "SDL_GPUGraphicsPipelineCreateInfo::multisample_state")]
+    pub fn with_multisample_state(mut self, value: MultisampleState) -> Self {
+        self.inner.multisample_state = value.inner;
         self
     }
 
@@ -387,6 +394,31 @@ impl RasterizerState {
     /// True to enable depth clip, false to enable depth clamp.
     pub fn with_enable_depth_clip(mut self, value: bool) -> Self {
         self.inner.enable_depth_clip = value;
+        self
+    }
+}
+
+/// The multisample state of a graphics pipeline.
+#[repr(C)]
+#[derive(Default, Copy, Clone)]
+#[doc(alias = "SDL_GPUMultisampleState")]
+pub struct MultisampleState {
+    inner: SDL_GPUMultisampleState,
+}
+impl MultisampleState {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// The number of samples to be used in rasterization.
+    pub fn with_sample_count(mut self, value: SampleCount) -> Self {
+        self.inner.sample_count = SDL_GPUSampleCount(value as i32);
+        self
+    }
+
+    /// True enables the alpha-to-coverage feature.
+    pub fn with_enable_alpha_to_coverage(mut self, value: bool) -> Self {
+        self.inner.enable_alpha_to_coverage = value;
         self
     }
 }


### PR DESCRIPTION
Adds the missing pieces needed to do MSAA through the safe GPU API.

`ColorTargetInfo` gets `with_resolve_texture`, plus `with_resolve_mip_level`, `with_resolve_layer` and `with_cycle_resolve_texture` for the companion fields, so a multisampled target can be resolved with `StoreOp::RESOLVE` without reaching into the raw struct.

New `MultisampleState` builder wrapping `SDL_GPUMultisampleState` with `with_sample_count` and `with_enable_alpha_to_coverage`, exported from `sdl3::gpu` and hooked up via `GraphicsPipelineBuilder::with_multisample_state`. `sample_mask` / `enable_mask` are documented as reserved by SDL so there are no setters for them.

Closes #431
Closes #430
