### PR TITLE
feat: made conversions from i/u32 to and from keycodes and scancodes constant

### DIFF
--- a/src/sdl3/keyboard/keycode.rs
+++ b/src/sdl3/keyboard/keycode.rs
@@ -265,7 +265,7 @@ impl Keycode {
     /// Creates a Keycode from a u32 value.
     ///
     /// This matches SDL3's SDL_Keycode type which is u32.
-    pub fn from_u32(n: u32) -> Option<Keycode> {
+    pub const fn from_u32(n: u32) -> Option<Keycode> {
         use self::Keycode::*;
         let n = SDL_Keycode(n);
 
@@ -532,11 +532,11 @@ impl Keycode {
         since = "0.18.0",
         note = "Use from_u32 instead. SDL3's SDL_Keycode is u32."
     )]
-    pub fn from_i32(n: i32) -> Option<Keycode> {
+    pub const fn from_i32(n: i32) -> Option<Keycode> {
         Self::from_u32(n as u32)
     }
 
-    pub fn to_ll(self) -> SDL_Keycode {
+    pub const fn to_ll(self) -> SDL_Keycode {
         SDL_Keycode(self as u32)
     }
 }

--- a/src/sdl3/keyboard/scancode.rs
+++ b/src/sdl3/keyboard/scancode.rs
@@ -260,7 +260,7 @@ pub enum Scancode {
 }
 
 impl Scancode {
-    pub fn from_i32(n: i32) -> Option<Scancode> {
+    pub const fn from_i32(n: i32) -> Option<Scancode> {
         use self::Scancode::*;
 
         Some(match SDL_Scancode(n) {
@@ -517,7 +517,7 @@ impl Scancode {
         })
     }
 
-    pub fn to_i32(self) -> i32 {
+    pub const fn to_i32(self) -> i32 {
         self as i32
     }
 }


### PR DESCRIPTION
For my usage case, I'd like to initialize a static value to a key code for detecting double taps, however, the functions are not constant despite having a constant implementation. This fixes that and shouldn't break anything.