### PR TITLE
feat(ttf): Support fallback fonts

### DIFF
--- a/examples/ttf-demo.rs
+++ b/examples/ttf-demo.rs
@@ -41,7 +41,7 @@ fn get_centered_rect(rect_width: u32, rect_height: u32, cons_width: u32, cons_he
     rect!(cx, cy, w, h)
 }
 
-fn run(font_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn run(font_path: &Path, fallback_path: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
     let sdl_context = sdl3::init()?;
     let video_subsys = sdl_context.video()?;
     let ttf_context = sdl3::ttf::init().map_err(|e| e.to_string())?;
@@ -59,10 +59,20 @@ fn run(font_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     // Load a font
     let mut font = ttf_context.load_font(font_path, 128.0)?;
     font.set_style(sdl3::ttf::FontStyle::BOLD);
+    if let Some(font_path) = fallback_path {
+        let mut fallback = ttf_context.load_font(font_path, 128.0)?;
+        fallback.set_style(sdl3::ttf::FontStyle::BOLD);
+        font.add_fallback_font(&fallback)?;
+        std::mem::forget(fallback);
+    }
 
     // render a surface, and convert it to a texture bound to the canvas
     let surface = font
-        .render("Hello Rust!")
+        .render(if fallback_path.is_some() {
+            "Hello Rust! 你好 Rust!"
+        } else {
+            "Hello Rust!"
+        })
         .blended(Color::RGBA(255, 0, 0, 255))
         .map_err(|e| e.to_string())?;
     let texture = texture_creator
@@ -108,10 +118,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("linked sdl3_ttf: {}", sdl3::ttf::get_linked_version());
 
     if args.len() < 2 {
-        println!("Usage: ./demo font.[ttf|ttc|fon]")
+        println!("Usage: ./demo font.[ttf|ttc|fon] [font.[ttf|ttc|fon]]")
     } else {
         let path: &Path = Path::new(&args[1]);
-        run(path)?;
+        let path_fb = args.get(2).map(|s| Path::new(s));
+        run(path, path_fb)?;
     }
 
     Ok(())

--- a/src/sdl3/ttf/font.rs
+++ b/src/sdl3/ttf/font.rs
@@ -386,6 +386,41 @@ impl<'r> Font<'r> {
         }
     }
 
+    /// Attaches another font to this one, to be used for substituting missing glyphs.
+    ///
+    /// ### Safety
+    ///
+    /// As of SDL_ttf 3.2.2, the behavior when a fallback font is dropped is to simply
+    /// ignore the stale reference.
+    ///
+    /// As such, user code may find it desirable to continue holding a reference to the fallback
+    /// font. Doing so is also required for adjusting the font settings, which are not inherited
+    /// from the parent font.
+    ///
+    /// Alternatively, it is possible to use `std::mem::forget` to force the fallback font(s) to not
+    /// be dropped.
+    #[doc(alias = "TTF_AddFallbackFont")]
+    pub fn add_fallback_font(&mut self, other: &Font<'static>) -> Result<(), Error> {
+        let ret = unsafe { ttf::TTF_AddFallbackFont(self.raw, other.raw) };
+        if !ret {
+            Err(get_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Detaches a fallback font
+    #[doc(alias = "TTF_RemoveFallbackFont")]
+    pub fn remove_fallback_font(&mut self, other: &Font<'static>) {
+        unsafe { ttf::TTF_RemoveFallbackFont(self.raw, other.raw) }
+    }
+
+    /// Detaches all fallback fonts
+    #[doc(alias = "TTF_ClearFallbackFont")]
+    pub fn clear_fallback_font(&mut self) {
+        unsafe { ttf::TTF_ClearFallbackFonts(self.raw) }
+    }
+
     /// Sets the font's style flags.
     #[doc(alias = "TTF_SetFontStyle")]
     pub fn set_style(&mut self, styles: FontStyle) {


### PR DESCRIPTION
Support the [`TTF_*FallbackFont`](https://wiki.libsdl.org/SDL3_ttf/TTF_AddFallbackFont) family of functions.

Currently I only handled the case of the fallback font having a `'static` lifetime, as that is what's relevant for my project. This may be undesirable.

-----

Screenshot rendered with: `cargo run --example ttf-demo --features ttf "/path/to/ComicCode-Regular.otf" /path/to/unifont.otf`, sdl3_ttf 3.2.2

<img width="804" height="604" alt="SDL3 demo showing text: Hello Rust! 你好 Rust!" src="https://github.com/user-attachments/assets/93c5619b-2c2e-4fa3-9dca-d0a4ba7c4bd2" />

